### PR TITLE
Attempt to support keys from JS - Take one

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchConfig.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchConfig.java
@@ -126,4 +126,17 @@ public class RNBranchConfig {
             return false;
         }
     }
+
+    public boolean getDeferInitializationForJSLoad() {
+        if (mConfiguration == null) return false;
+
+        try {
+            if (!mConfiguration.has("deferInitializationForJSLoad")) return false;
+            return mConfiguration.getBoolean("deferInitializationForJSLoad");
+        }
+        catch (JSONException exception) {
+            Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());
+            return false;
+        }
+    }
 }

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -117,15 +117,17 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
         mActivity = reactActivity;
         mSavedUri = uri;
 
-        if (mDeferInitializationForJSLoad) {
+        RNBranchConfig config = new RNBranchConfig(reactActivity);
+
+        if (mDeferInitializationForJSLoad || config.getDeferInitializationForJSLoad()) {
             return;
         }
 
-        initializeNativeSDK();
+        initializeNativeSDK(null);
     }
 
-    private static void initializeNativeSDK() {
-        Branch branch = setupBranch(mActivity.getApplicationContext());
+    private static void initializeNativeSDK(@Nullable String key) {
+        Branch branch = setupBranch(key, mActivity.getApplicationContext());
 
         branch.initSession(new Branch.BranchReferralInitListener(){
 
@@ -345,14 +347,17 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void initializeBranch(String key, Promise promise) {
-        if (!mDeferInitializationForJSLoad) {
+        RNBranchConfig config = new RNBranchConfig(mActivity);
+
+        if (!mDeferInitializationForJSLoad && !config.getDeferInitializationForJSLoad()) {
+            // TODO: Reject if key is non-null. Too late now.
             promise.resolve(0);
             return;
         }
 
-        Log.d(REACT_CLASS, "key from JS: " + key);
+        Log.d(REACT_CLASS, "Initializing Branch SDK. Key from JS: " + key);
 
-        initializeNativeSDK();
+        initializeNativeSDK(key);
 
         promise.resolve(0);
     }
@@ -673,8 +678,17 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
         return linkProperties;
     }
 
-    private static Branch setupBranch(Context context) {
-        Branch branch = Branch.getInstance(context);
+    private static Branch setupBranch(@Nullable String key, Context context) {
+        Branch branch;
+
+        if (key == null) key = getBranchKeyFromConfiguration(context);
+
+        if (key != null) {
+            branch = Branch.getInstance(context, key);
+        }
+        else {
+            branch = Branch.getInstance(context);
+        }
 
         if (!mInitialized) {
             Log.i(REACT_CLASS, "Initializing Branch SDK v. " + BuildConfig.VERSION_NAME);
@@ -686,9 +700,9 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
             if (mRequestMetadata != null) {
                 Iterator keys = mRequestMetadata.keys();
                 while (keys.hasNext()) {
-                    String key = (String) keys.next();
+                    String metadataKey = (String) keys.next();
                     try {
-                        branch.setRequestMetadata(key, mRequestMetadata.getString(key));
+                        branch.setRequestMetadata(metadataKey, mRequestMetadata.getString(metadataKey));
                     } catch (JSONException e) {
                         // no-op
                     }
@@ -699,6 +713,20 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
         }
 
         return branch;
+    }
+
+    @Nullable
+    private static String getBranchKeyFromConfiguration(Context context) {
+        RNBranchConfig config = new RNBranchConfig(context);
+        String key = config.getBranchKey();
+        if (key != null) return key;
+
+        if (config.getUseTestInstance()) {
+            return config.getTestKey();
+        }
+        else {
+            return config.getLiveKey();
+        }
     }
 
     private BranchUniversalObject findUniversalObjectOrReject(final String ident, final Promise promise) {

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -82,6 +82,8 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     private static boolean mUseDebug = false;
     private static boolean mInitialized = false;
     private static JSONObject mRequestMetadata = new JSONObject();
+    private static boolean mDeferInitializationForJSLoad = false;
+    private static Uri mSavedUri = null;
 
     private AgingHash<String, BranchUniversalObject> mUniversalObjectMap = new AgingHash<>(AGING_HASH_TTL);
 
@@ -112,9 +114,19 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     public static void initSession(final Uri uri, Activity reactActivity) {
-        Branch branch = setupBranch(reactActivity.getApplicationContext());
-
         mActivity = reactActivity;
+        mSavedUri = uri;
+
+        if (mDeferInitializationForJSLoad) {
+            return;
+        }
+
+        initializeNativeSDK();
+    }
+
+    private static void initializeNativeSDK() {
+        Branch branch = setupBranch(mActivity.getApplicationContext());
+
         branch.initSession(new Branch.BranchReferralInitListener(){
 
             private Activity mmActivity = null;
@@ -208,7 +220,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
 
                 LocalBroadcastManager.getInstance(mmActivity).sendBroadcast(broadcastIntent);
             }
-        }.init(reactActivity), uri, reactActivity);
+        }.init(mActivity), mSavedUri, mActivity);
     }
 
     public static void setDebug() {
@@ -229,6 +241,10 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
         } catch (JSONException e) {
             // no-op
         }
+    }
+
+    public static void setmDeferInitializationForJSLoad() {
+        mDeferInitializationForJSLoad = true;
     }
 
     public RNBranchModule(ReactApplicationContext reactContext) {
@@ -325,6 +341,20 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     public void isTrackingDisabled(Promise promise) {
         Branch branch = Branch.getInstance();
         promise.resolve(branch.isTrackingDisabled());
+    }
+
+    @ReactMethod
+    public void initializeBranch(String key, Promise promise) {
+        if (!mDeferInitializationForJSLoad) {
+            promise.resolve(0);
+            return;
+        }
+
+        Log.d(REACT_CLASS, "key from JS: " + key);
+
+        initializeNativeSDK();
+
+        promise.resolve(0);
     }
 
     @ReactMethod

--- a/examples/webview_example/android/app/src/main/AndroidManifest.xml
+++ b/examples/webview_example/android/app/src/main/AndroidManifest.xml
@@ -14,10 +14,10 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="rnwebview" android:host="open"/>
-                <data android:scheme="https" android:host="ms9y.app.link"/>
-                <data android:scheme="https" android:host="ms9y-alternate.app.link"/>
-                <data android:scheme="https" android:host="ms9y.test-app.link"/>
-                <data android:scheme="https" android:host="ms9y-alternate.test-app.link"/>
+                <data android:scheme="https" android:host="l1mv.app.link"/>
+                <data android:scheme="https" android:host="l1mv-alternate.app.link"/>
+                <data android:scheme="https" android:host="l1mv.test-app.link"/>
+                <data android:scheme="https" android:host="l1mv-alternate.test-app.link"/>
             </intent-filter>
         </activity>
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>

--- a/examples/webview_example/android/app/src/main/java/com/webview_example/MainApplication.java
+++ b/examples/webview_example/android/app/src/main/java/com/webview_example/MainApplication.java
@@ -50,7 +50,7 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
         SoLoader.init(this, /* native exopackage */ false);
 
         // Replace Branch.getAutoInstance(this); with:
-        RNBranchModule.saveApplicationContext(this);
+        RNBranchModule.getAutoInstance(this);
     }
 
     @Override

--- a/examples/webview_example/android/app/src/main/java/com/webview_example/MainApplication.java
+++ b/examples/webview_example/android/app/src/main/java/com/webview_example/MainApplication.java
@@ -19,23 +19,49 @@ import java.util.List;
 
 public class MainApplication extends MultiDexApplication implements ReactApplication {
 
-  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+    private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+            return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+            return Arrays.<ReactPackage>asList(
+                    new MainReactPackage(),
+                    new RNBranchPackage()
+            );
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+            return "index";
+        }
+    };
+
     @Override
-    public boolean getUseDeveloperSupport() {
-      return BuildConfig.DEBUG;
+    public ReactNativeHost getReactNativeHost() {
+        return mReactNativeHost;
     }
 
     @Override
-    protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-            new RNBranchPackage()
-      );
+    public void onCreate() {
+        super.onCreate();
+        SoLoader.init(this, /* native exopackage */ false);
+
+        // Replace Branch.getAutoInstance(this); with:
+        RNBranchModule.saveApplicationContext(this);
     }
 
     @Override
-    protected String getJSMainModuleName() {
-      return "index";
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+
+        // Most prod apps seem to use multidex, so though it's not necessary with this small app,
+        // this seems to make it a more realistic example. This has had an impact on build issues
+        // before, so probably best to match partner apps as much as possible.
+        // TODO: Shouldn't this be in onCreate? If here, should the base context be used?
+        MultiDex.install(this);
     }
   };
 

--- a/examples/webview_example/branch.debug.json
+++ b/examples/webview_example/branch.debug.json
@@ -2,5 +2,6 @@
     "debugMode": true,
     "delayInitToCheckForSearchAds": true,
     "appleSearchAdsDebugMode": true,
-    "branchKey": "key_test_oaCHnPu3yWd42Pn2F4YfIgdlBAmPac1G"
+    "branchKey": "key_test_oaCHnPu3yWd42Pn2F4YfIgdlBAmPac1G",
+    "deferInitializationForJSLoad": true
 }

--- a/examples/webview_example/branch.debug.json
+++ b/examples/webview_example/branch.debug.json
@@ -1,7 +1,7 @@
 {
-    "debugMode": true,
-    "delayInitToCheckForSearchAds": true,
-    "appleSearchAdsDebugMode": true,
-    "branchKey": "key_test_oaCHnPu3yWd42Pn2F4YfIgdlBAmPac1G",
-    "deferInitializationForJSLoad": true
+  "debugMode": true,
+  "delayInitToCheckForSearchAds": true,
+  "appleSearchAdsDebugMode": true,
+  "deferInitializationForJSLoad": true,
+  "branchKey": "key_test_oaCHnPu3yWd42Pn2F4YfIgdlBAmPac1G"
 }

--- a/examples/webview_example/branch.json
+++ b/examples/webview_example/branch.json
@@ -1,4 +1,6 @@
 {
   "delayInitToCheckForSearchAds": true,
-  "branchKey": "key_live_gmvPhLx7x9cW5Qh4x80dVcphxviJom1r"
+  "branchKey": "key_live_gmvPhLx7x9cW5Qh4x80dVcphxviJom1r",
+  "delayInitToCheckForSearchAds": true,
+  "deferInitializationForJSLoad": true
 }

--- a/examples/webview_example/branch.json
+++ b/examples/webview_example/branch.json
@@ -1,6 +1,5 @@
 {
   "delayInitToCheckForSearchAds": true,
   "branchKey": "key_live_gmvPhLx7x9cW5Qh4x80dVcphxviJom1r",
-  "delayInitToCheckForSearchAds": true,
   "deferInitializationForJSLoad": true
 }

--- a/examples/webview_example/src/ArticleList.js
+++ b/examples/webview_example/src/ArticleList.js
@@ -35,6 +35,7 @@ class ArticleList extends Component {
   }
 
   componentDidMount() {
+    branch.key = 'key_test_jmzd0lUR9gIiAAEQfo42onbcExe1MeHg'
     this._unsubscribeFromBranch = branch.subscribe(({ error, params }) => {
       if (error) {
         console.error("Error from Branch: " + error)

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -153,7 +153,7 @@ RCT_EXPORT_MODULE();
 + (void)useTestInstance {
     useTestInstance = YES;
 }
-    
+
 + (void)deferInitializationForJSLoad
 {
     deferInitializationForJSLoad = YES;
@@ -164,9 +164,7 @@ RCT_EXPORT_MODULE();
     savedLaunchOptions = launchOptions;
     savedIsReferrable = isReferrable;
 
-    // Can't currently support this on Android.
-    // if (!deferInitializationForJSLoad && !RNBranchConfig.instance.deferInitializationForJSLoad) [self initializeBranchSDK];
-    [self initializeBranchSDK];
+    if (!deferInitializationForJSLoad && !RNBranchConfig.instance.deferInitializationForJSLoad) [self initializeBranchSDK];
 }
 
 + (void)initializeBranchSDK
@@ -177,14 +175,14 @@ RCT_EXPORT_MODULE();
         if (params) {
             result[RNBranchLinkOpenedNotificationParamsKey] = params;
             BOOL clickedBranchLink = params[@"+clicked_branch_link"];
-            
+
             if (clickedBranchLink) {
                 BranchUniversalObject *branchUniversalObject = [BranchUniversalObject objectWithDictionary:params];
                 if (branchUniversalObject) result[RNBranchLinkOpenedNotificationBranchUniversalObjectKey] = branchUniversalObject;
-                
+
                 BranchLinkProperties *linkProperties = [BranchLinkProperties getBranchLinkPropertiesFromDictionary:params];
                 if (linkProperties) result[RNBranchLinkOpenedNotificationLinkPropertiesKey] = linkProperties;
-                
+
                 if (params[@"~referring_link"]) {
                     result[RNBranchLinkOpenedNotificationUriKey] = [NSURL URLWithString:params[@"~referring_link"]];
                 }
@@ -193,7 +191,7 @@ RCT_EXPORT_MODULE();
                 result[RNBranchLinkOpenedNotificationUriKey] = [NSURL URLWithString:params[@"+non_branch_link"]];
             }
         }
-        
+
         [[NSNotificationCenter defaultCenter] postNotificationName:RNBranchLinkOpenedNotification object:nil userInfo:result];
     }];
 }
@@ -311,13 +309,7 @@ RCT_EXPORT_METHOD(initializeBranch:(NSString *)key
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
                   ) {
-    NSError *error = [NSError errorWithDomain:RNBranchErrorDomain
-                                         code:-1
-                                     userInfo:nil];
-    
-    reject(@"RNBranch::Error::Unsupported", @"Initializing the Branch SDK from JS will be supported in a future release.", error);
-
-    /*
+    //*
     if (!deferInitializationForJSLoad && !RNBranchConfig.instance.deferInitializationForJSLoad) {
         // This is a no-op from JS unless [RNBranch deferInitializationForJSLoad] is called.
         resolve(0);

--- a/native-tests/ios/NativeTests.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/native-tests/ios/NativeTests.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/src/index.js
+++ b/src/index.js
@@ -76,8 +76,7 @@ class Branch {
     }
 
     // Initialize the native Branch SDK from JS
-    // -- Unsupportable on Android for the time being.
-    // RNBranch.initializeBranch(this.key)
+    RNBranch.initializeBranch(this.key)
 
     const unsubscribe = () => {
       this._removeListener(listener)


### PR DESCRIPTION
*Not ready to merge*

The obstacle to doing this has always been `Branch.getAutoInstance()`. This change defers it until JS loads, but even saving the application context from `Application.onCreate()` does not work. Presumably there is some dependency on state, which is lost by the time this is called. If you remove `deferInitializationForJSLoad` from `branch.json` and restore the commented keys in the Android manifest, everything works normally.

I'll work with the Branch devs to figure out what needs to change in the native Android SDK for this to work. That SDK has always been closely tied to the application and activity lifecycles, which has made it difficult to support this sort of feature here and in the Branch Titanium SDK. This will have to be prioritized, and maybe with a bit of guidance I can contribute a change to the Android SDK to help speed things along.

Watch this space.