### PR TITLE
Update instructions to upgrade to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,6 @@ module, starting with version 3.0.0.
 
 Open the `android/app/build.gradle` file in your project.
 
-Remove this line:
-
-```gradle
-implementation fileTree(dir: 'libs', include: ['*.jar'])
-```
-
 Add this line:
 
 ```gradle
@@ -116,6 +110,7 @@ The result should be something like
 dependencies {
     implementation project(':react-native-branch')
     implementation "io.branch.sdk.android:library:3.0.4"
+    implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:23.0.1"
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }


### PR DESCRIPTION
`implementation fileTree(dir: "libs", include: ["*.jar"])` is included in React Native’s `android/app/build.gradle` [by default](https://github.com/facebook/react-native/blob/3b91a7ec234b9aebfe11bb1c94de7b41444b57f2/template/android/app/build.gradle#L141). Removing it might affect other packages and since the `libs` directory was removed in 1d2925b1fa954bfe6088deb75958672533b7af1f anyway, it should not be necessary to remove this line.