### PR TITLE
Carthage support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+' // From node_modules
-    api 'io.branch.sdk.android:library:3.1.2'
+    api 'io.branch.sdk.android:library:3.2.0'
 }

--- a/ios/RNBranch.xcodeproj/project.pbxproj
+++ b/ios/RNBranch.xcodeproj/project.pbxproj
@@ -345,7 +345,10 @@
 		B3A3CC401C5B0A070016AC52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/Branch";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(BUILT_PRODUCTS_DIR)/Branch",
+					"$(SRCROOT)/../../../ios/Carthage/Build/iOS",
+				);
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Pods/Headers/Public";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "react-native-branch";
@@ -356,7 +359,10 @@
 		B3A3CC411C5B0A070016AC52 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/Branch";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(BUILT_PRODUCTS_DIR)/Branch",
+					"$(SRCROOT)/../../../ios/Carthage/Build/iOS",
+				);
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Pods/Headers/Public";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "react-native-branch";


### PR DESCRIPTION
Added Carthage/Build/iOS to Framework Search Paths in order to support installing Branch.framework via Carthage.

Bumped native Android SDK to 3.2.0 in preparation for release.

Docs PR to follow momentarily.