### PR TITLE
Fix/migrate to android x

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -6,8 +6,8 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.BroadcastReceiver;
 import android.net.Uri;
-import android.support.annotation.Nullable;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.annotation.Nullable;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.util.Log;
 import android.os.Handler;
 
@@ -25,7 +25,6 @@ import io.branch.indexing.*;
 
 import org.json.*;
 
-import java.lang.ref.WeakReference;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -84,27 +83,6 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     private static JSONObject mRequestMetadata = new JSONObject();
 
     private AgingHash<String, BranchUniversalObject> mUniversalObjectMap = new AgingHash<>(AGING_HASH_TTL);
-
-    public static void getAutoInstance(Context context) {
-        RNBranchConfig config = new RNBranchConfig(context);
-        String branchKey = config.getBranchKey();
-        String liveKey = config.getLiveKey();
-        String testKey = config.getTestKey();
-        boolean useTest = config.getUseTestInstance();
-
-        if (branchKey != null) {
-            Branch.getAutoInstance(context, branchKey);
-        }
-        else if (useTest && testKey != null) {
-            Branch.getAutoInstance(context, testKey);
-        }
-        else if (!useTest && liveKey != null) {
-            Branch.getAutoInstance(context, liveKey);
-        }
-        else {
-            Branch.getAutoInstance(context);
-        }
-    }
 
     public static void initSession(final Uri uri, Activity reactActivity, Branch.BranchUniversalReferralInitListener anInitListener) {
         initListener = anInitListener;

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -25,6 +25,7 @@ import io.branch.indexing.*;
 
 import org.json.*;
 
+import java.lang.ref.WeakReference;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -83,6 +84,27 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     private static JSONObject mRequestMetadata = new JSONObject();
 
     private AgingHash<String, BranchUniversalObject> mUniversalObjectMap = new AgingHash<>(AGING_HASH_TTL);
+
+    public static void getAutoInstance(Context context) {
+        RNBranchConfig config = new RNBranchConfig(context);
+        String branchKey = config.getBranchKey();
+        String liveKey = config.getLiveKey();
+        String testKey = config.getTestKey();
+        boolean useTest = config.getUseTestInstance();
+
+        if (branchKey != null) {
+            Branch.getAutoInstance(context, branchKey);
+        }
+        else if (useTest && testKey != null) {
+            Branch.getAutoInstance(context, testKey);
+        }
+        else if (!useTest && liveKey != null) {
+            Branch.getAutoInstance(context, liveKey);
+        }
+        else {
+            Branch.getAutoInstance(context);
+        }
+    }
 
     public static void initSession(final Uri uri, Activity reactActivity, Branch.BranchUniversalReferralInitListener anInitListener) {
         initListener = anInitListener;


### PR DESCRIPTION
Fixings these errors:
```
node_modules/react-native-branch/android/src/main/java/io/branch/rnbranch/RNBranchModule.java:9: error: package android.support.annotation does not exist
import android.support.annotation.Nullable;
                                 ^
node_modules/react-native-branch/android/src/main/java/io/branch/rnbranch/RNBranchModule.java:10: error: package android.support.v4.content does not exist
import android.support.v4.content.LocalBroadcastManager;
                                 ^
```
Library migrated to AndroidX.
![image](https://user-images.githubusercontent.com/17846448/59919960-98d64b80-9431-11e9-8049-91555f1cdf5e.png)
