### PR TITLE
[ios] Fix clicked_branch_link false positive

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -183,7 +183,7 @@ RCT_EXPORT_MODULE();
         if (error) result[RNBranchLinkOpenedNotificationErrorKey] = error;
         if (params) {
             result[RNBranchLinkOpenedNotificationParamsKey] = params;
-            BOOL clickedBranchLink = params[@"+clicked_branch_link"];
+            BOOL clickedBranchLink = [params[@"+clicked_branch_link"] boolValue];
 
             if (clickedBranchLink) {
                 BranchUniversalObject *branchUniversalObject = [BranchUniversalObject objectWithDictionary:params];


### PR DESCRIPTION
Before this change a pointer was being interpreted as a BOOL value, so:
- `nil` would become `false`
- `NSNumber` representing 1 would become `true`
- `NSNumber` representing 0 would also become `true` (a pointer would be non-null)

This change should fix the issue and interpret the value properly.