### PR TITLE
Use getLatestReferringParamsSync[hronous] in the native layers

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -351,7 +351,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void getLatestReferringParams(Promise promise) {
         Branch branch = Branch.getInstance();
-        promise.resolve(convertJsonToMap(branch.getLatestReferringParams()));
+        promise.resolve(convertJsonToMap(branch.getLatestReferringParamsSync()));
     }
 
     @ReactMethod

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -352,7 +352,7 @@ RCT_EXPORT_METHOD(
                   getLatestReferringParams:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject
                   ) {
-    resolve([self.class.branch getLatestReferringParams]);
+    resolve([self.class.branch getLatestReferringParamsSynchronous]);
 }
 
 #pragma mark getFirstReferringParams


### PR DESCRIPTION
Fix #465 

This has always worked as designed. There may be no meaningful return value to getLatestReferringParams until the callback to branch.subscribe returns. If the app has previously been opened on the device, the latest referring params will be returned from user defaults (iOS) or user preferences (Android), which may be from a previous run of the app. In that case, the method will return before the callback to subscribe. This is a race:

```js
branch.subscribe(({params, error} => {
  // ...
})
let latestParams = await branch.getLatestReferringParams()
```

This is not a race:

```js
branch.subscribe(({params, error} => {
  // ...
  let latestParams = await branch.getLatestReferringParams()
  // of course, latestParams == params, so there's not much case for using the method here
})
```

Both native SDKs expose both an asynchronous getLatestReferringParams and a synchronous equivalent that blocks until a response is received. In native code, these synchronous methods cannot be called on the main thread and must be dispatched to the background. Given the Redux pattern with RN, everything returns a promise, and there's no possibility to block the calling thread. There's little difference between exposing the synchronous and asynchronous methods to JS, except that exposing the synchronous methods guarantees that promises don't return until the callback to subscribe is ready to return (or already has). This was never a design goal in this SDK, but it's a common enough expectation, and this is a trivial change to make that doesn't introduce extra code in JS to maintain.

Android also has getFirstReferringParamsSync, but iOS doesn't have a synchronous equivalent to that method, so the getFirstReferringParams method here is still asynchronous and may still produce a race. It's possible to address this in JS, but if this is a generally desirable feature, it might be best to implement the synchronous method for iOS. Since it exists on Android, this may just be an oversight on iOS.

This will have to be released for 3.x (RN < 0.60) and 4.x (RN >= 0.60).