### PR TITLE
Synchronous option for get latest referring params

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,21 +504,27 @@ These session parameters will be available at any point later on with this comma
 #### Method
 
 ```js
-branch.getLatestReferringParams()
+branch.getLatestReferringParams(synchronous = false)
 ```
 
 ##### Return
 
 A promise. On resolution, the promise returns an object containing the parameters
 from the latest link open or install. See [Params object](#params-object) for
-details on the contents.
+details on the contents. Depending on the value of the argument, the promise may
+return right away, possibly with values from the user defaults (iOS) or user
+preferences (Android) or wait until an open response is received.
 
 #### Example
 
 ```js
 import branch from 'react-native-branch'
 
+// don't wait for open response
 const latestParams = await branch.getLatestReferringParams()
+
+// wait for open response
+const latestParams = await branch.getLatestReferringParams(true)
 ```
 
 ___

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -349,9 +349,12 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void getLatestReferringParams(Promise promise) {
+    public void getLatestReferringParams(boolean synchronous, Promise promise) {
         Branch branch = Branch.getInstance();
-        promise.resolve(convertJsonToMap(branch.getLatestReferringParamsSync()));
+        if (synchronous)
+            promise.resolve(convertJsonToMap(branch.getLatestReferringParamsSync()));
+        else
+            promise.resolve(convertJsonToMap(branch.getLatestReferringParams()));
     }
 
     @ReactMethod

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -349,10 +349,14 @@ RCT_EXPORT_METHOD(
 
 #pragma mark getLatestReferringParams
 RCT_EXPORT_METHOD(
-                  getLatestReferringParams:(RCTPromiseResolveBlock)resolve
+                  getLatestReferringParams:(NSNumber*)synchronous
+                  resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject
                   ) {
-    resolve([self.class.branch getLatestReferringParamsSynchronous]);
+    if (synchronous.boolValue)
+        resolve([self.class.branch getLatestReferringParamsSynchronous]);
+    else
+        resolve([self.class.branch getLatestReferringParams]);
 }
 
 #pragma mark getFirstReferringParams

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -349,7 +349,7 @@ RCT_EXPORT_METHOD(
 
 #pragma mark getLatestReferringParams
 RCT_EXPORT_METHOD(
-                  getLatestReferringParams:(NSNumber*)synchronous
+                  getLatestReferringParams:(NSNumber* __nonnull)synchronous
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject
                   ) {

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ class Branch {
 
   /*** RNBranch singleton methods ***/
   setDebug = () => { throw 'setDebug() is not supported in the RN SDK. For other solutions, please see https://rnbranch.app.link/setDebug' }
-  getLatestReferringParams = RNBranch.getLatestReferringParams
+  getLatestReferringParams = (synchronous = false) => RNBranch.getLatestReferringParams(synchronous)
   getFirstReferringParams = RNBranch.getFirstReferringParams
   setIdentity = (identity) => RNBranch.setIdentity(identity)
   logout = RNBranch.logout


### PR DESCRIPTION
Follow up to #479. Related to #465 

Added an option to getLatestReferringParams to specify synchronous/asynchronous behavior, to avoid breaking any app that relies on the current behavior. By default, the method will remain asynchronous. To wait until an open response is received, use `getLatestReferringParams(true)`.

Also, the remarks for #479 were inaccurate. The synchronous methods will always wait until an open response is received, which is to say when the branch.subscribe callback returns. Only when called asynchronously will the method possibly return data from the user defaults/preferences from a previous app run.