### PR TITLE
Lock branch.io sdk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+' // From node_modules
-    implementation 'io.branch.sdk.android:library:+'
+    implementation 'io.branch.sdk.android:library:3.2.0'
     // TODO: Resolve build issue with this jar.
     // implementation files('libs/Branch-3.0.3.jar') // From node_modules
 }


### PR DESCRIPTION
The last `io.branch.sdk.android` release to maven broke our builds. We are using `react-native-branch@2.3.5`.
Will it be possible to release a new 2.x.x version with this lock?

Thanks