### PR TITLE
Update React-Native-Branch v3 to support Branch ios v0.28.1

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -90,7 +90,7 @@ RCT_EXPORT_MODULE();
         [instance delayInitToCheckForSearchAds];
     }
     if (config.appleSearchAdsDebugMode) {
-        [instance setAppleSearchAdsDebugMode];
+        [RNBranch setAppleSearchAdsDebugMode];
     }
 }
 
@@ -149,7 +149,7 @@ RCT_EXPORT_MODULE();
 
 + (void)setAppleSearchAdsDebugMode
 {
-    [self.branch setAppleSearchAdsDebugMode];
+    [RNBranch setAppleSearchAdsDebugMode];
 }
 
 + (void)setRequestMetadataKey:(NSString *)key value:(NSObject *)value

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -29,7 +29,7 @@ static NSString * const IdentFieldName = @"ident";
 static NSString * const RNBranchErrorDomain = @"RNBranchErrorDomain";
 static NSInteger const RNBranchUniversalObjectNotFoundError = 1;
 
-static NSString * const REQUIRED_BRANCH_SDK = @"0.27.1";
+static NSString * const REQUIRED_BRANCH_SDK = @"0.28.1";
 
 #pragma mark - Private RNBranch declarations
 


### PR DESCRIPTION
Fixing error:
```
No visible @interface for 'Branch' declares the selector 'setAppleSearchAdsDebugMode'
```

by calling static method instead of instance.

This patch is necessary to build with ios branch version 0.28.1