### PR TITLE
Fixed erroneous AchievementUnlocked -> UnlockAchievement in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,7 +792,7 @@ new BranchEvent(BranchEvent.Purchase, buo, { revenue: 20 }).logEvent()
 |BranchEvent.CompleteRegistration|Standard Complete Registration event|
 |BranchEvent.CompleteTutorial|Standard Complete Tutorial event|
 |BranchEvent.AchieveLevel|Standard Achieve Level event|
-|BranchEvent.AchievementUnlocked|Standard Unlock Achievement event|
+|BranchEvent.UnlockAchievement|Standard Unlock Achievement event|
 
 ___
 


### PR DESCRIPTION
Fixed erroneous BranchEvent.{AchievementUnlocked -> UnlockAchievement} in readme

See https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution/blob/0650971479d1cb7567bb23fae1a8222b07fac1f4/src/BranchEvent.js#L294