### PR TITLE
Bump Branch SDK iOS dependency to 0.29.1

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -29,7 +29,7 @@ static NSString * const IdentFieldName = @"ident";
 static NSString * const RNBranchErrorDomain = @"RNBranchErrorDomain";
 static NSInteger const RNBranchUniversalObjectNotFoundError = 1;
 
-static NSString * const REQUIRED_BRANCH_SDK = @"0.29.0";
+static NSString * const REQUIRED_BRANCH_SDK = @"0.29.1";
 
 #pragma mark - Private RNBranch declarations
 

--- a/react-native-branch.podspec
+++ b/react-native-branch.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
   s.source       = { spec['repository']['type'].to_sym => spec['repository']['url'].sub(/^[a-z]+\+/, '') }
   s.source_files = [ "ios/*.h", "ios/*.m"]
   s.header_dir   = 'RNBranch' # also sets generated module name
-  s.dependency 'Branch', '0.29.0'
+  s.dependency 'Branch', '0.29.1'
   s.dependency 'React' # to ensure the correct build order
 end


### PR DESCRIPTION
This removes a lot of nullability warnings from xcode when building on
Xcode 11 or newer.

https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/pull/949