### PR TITLE
Make it explicit that manual step is required when using branch.json with RN > 0.60

### DIFF
--- a/docs/branch.json.md
+++ b/docs/branch.json.md
@@ -38,6 +38,8 @@ react-native link react-native-branch
 
 ### Manual integration without react-native link
 
+**NOTE: This is required for RN > 0.60**
+
 #### Android
 
 Put your `branch.json` file in `app/src/main/assets/branch.json`.


### PR DESCRIPTION
When installing fresh with RN > 0.60 it is unclear that manual step is required when using branch.json