### PR TITLE
update peer dependency for newer versions of RN

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution",
   "peerDependencies": {
-    "react-native": "^0.60.0"
+    "react-native": ">=0.60.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",


### PR DESCRIPTION
This should eliminate this warning when installing:
`warning " > react-native-branch@4.3.0" has incorrect peer dependency "react-native@^0.60.0".`