### PR TITLE
[SDK-926] Add localbroadcastmanager as a dependency to build.gradle.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation 'com.facebook.react:react-native:+' // From node_modules
     api 'io.branch.sdk.android:library:4.3.2'
 }


### PR DESCRIPTION
Fix #557 

With this change, I can create a new RN 0.61 app using react-native init, then yarn add this package from local source with these changes and react-native-screens, set up the Android native code, and run without a crash.

If I then revert to react-native-branch@4.4.0, I get the reported runtime error.