### PR TITLE
[SDK-1035] Handle Universal Links on cold launch (iOS)

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -169,6 +169,13 @@ RCT_EXPORT_MODULE();
 
 + (void)initializeBranchSDK
 {
+    // Universal Links
+    NSUserActivity *coldLaunchUserActivity = savedLaunchOptions[UIApplicationLaunchOptionsUserActivityDictionaryKey][@"UIApplicationLaunchOptionsUserActivityKey"];
+    if (coldLaunchUserActivity.webpageURL) {
+        [self willOpenURL:coldLaunchUserActivity.webpageURL];
+    }
+
+    // URI schemes
     NSURL *coldLaunchURL = savedLaunchOptions[UIApplicationLaunchOptionsURLKey];
     if (coldLaunchURL) {
         [self willOpenURL:coldLaunchURL];


### PR DESCRIPTION
This change handles Universal Links on iOS at cold launch by looking for the `UIApplicationLaunchOptionsUserActivityDictionaryKey` instead of `UIApplicationLaunchOptionsURLKey`. This is necessary to fire the `onOpenStart` method on cold launch from a Universal Link. That already happens when a UL is opened after launch via contineUserActivity:.