### PR TITLE
[SDK-1050] Return an appropriate function for unsubscribe.

### DIFF
--- a/native-tests/ios/Podfile.lock
+++ b/native-tests/ios/Podfile.lock
@@ -184,7 +184,7 @@ PODS:
     - React-cxxreact (= 0.62.0)
     - React-jsi (= 0.62.0)
   - React-jsinspector (0.62.0)
-  - react-native-branch (5.0.0-beta.2):
+  - react-native-branch (5.0.0-rc.1):
     - Branch (= 0.34.0)
     - React
   - React-RCTActionSheet (0.62.0):
@@ -377,7 +377,7 @@ SPEC CHECKSUMS:
   React-jsi: bc8166d6833cdcb0848c80710b26ce63fad2c099
   React-jsiexecutor: 8bf0b2707f05865113415088c398a7f98c0cf546
   React-jsinspector: 8e5913c4c6c54f0d3f9c9fc630c465a89cded65d
-  react-native-branch: c3f12fbc43ea98a9e8732cec78dfa83d525b7caf
+  react-native-branch: 102e3783f839366246b6f7ace5cbfdae954f1257
   React-RCTActionSheet: 674afbc8b9c76e0a83520e0a51da29a70802c03f
   React-RCTAnimation: f5f24330d09ee677fb49e0782f8321868f4df431
   React-RCTBlob: b773ce6138ab0d172ebd8a455fd4efd200a92549

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-branch",
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0-rc.1",
   "description": "Branch Metrics React Native SDK",
   "main": "src/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ class Branch {
     const subscriber = new BranchSubscriber(options)
     subscriber.subscribe()
 
-    return subscriber.unsubscribe
+    return () => subscriber.unsubscribe()
   }
 
   skipCachedEvents() {


### PR DESCRIPTION
Fix #590

Returning `subscriber.unsubscribe` from `branch.subscribe` somehow does not result in a working unsubscribe function. Changed to `return () => subscriber.unsubscribe()`, i.e. a function that calls that function. This consistently works in testing.