### PR TITLE
Add bug report email address to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "bugs": {
     "url": "https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution/issues",
-		"email": "support@branch.io"
+    "email": "support@branch.io"
   },
   "homepage": "https://help.branch.io/developers-hub/docs/react-native",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "url": "git+https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution.git"
   },
   "bugs": {
-    "url": "https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution/issues"
+    "url": "https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution/issues",
+		"email": "support@branch.io"
   },
   "homepage": "https://help.branch.io/developers-hub/docs/react-native",
   "peerDependencies": {


### PR DESCRIPTION
This was also done for the Web SDK. The URL takes precedence in some cases (certain NPM commands to report bugs, e.g.).