### PR TITLE
Cached result in onOpenStart

### DIFF
--- a/src/BranchSubscriber.js
+++ b/src/BranchSubscriber.js
@@ -73,9 +73,10 @@ export default class BranchSubscriber {
            * by caching the pending URI in the native layers.
            */
           if (this.options.onOpenStart && 'uri' in result) {
-            this.options.onOpenStart({uri: result.uri})
+            this.options.onOpenStart({uri: result.uri, cachedInitialEvent: true})
           }
           if (this.options.onOpenComplete) {
+            // result includes uri and +rn_cached_initial_event.
             this.options.onOpenComplete(result)
           }
         }

--- a/test/BranchSubscriber.test.js
+++ b/test/BranchSubscriber.test.js
@@ -97,7 +97,7 @@ test('will return a cached event when appropriate', done => {
 
       // uri passed to onOpenStart
       expect(subscriber.options.onOpenStart.mock.calls.length).toBe(1)
-      expect(subscriber.options.onOpenStart.mock.calls[0][0]).toEqual({uri: null})
+      expect(subscriber.options.onOpenStart.mock.calls[0][0]).toEqual({uri: null, cachedInitialEvent: true})
 
       // full result passed to onOpenComplete with +rn_cached_initial_event: true
       expect(subscriber.options.onOpenComplete.mock.calls.length).toBe(1)
@@ -145,7 +145,7 @@ test('passes a non-null uri to onOpenStart when available', done => {
       // Expect onOpenStart to be called
       // uri passed to onOpenStart
       expect(subscriber.options.onOpenStart.mock.calls.length).toBe(1)
-      expect(subscriber.options.onOpenStart.mock.calls[0][0]).toEqual({uri: mockResult.uri})
+      expect(subscriber.options.onOpenStart.mock.calls[0][0]).toEqual({uri: mockResult.uri, cachedInitialEvent: true})
 
       done()
     } catch(error) {


### PR DESCRIPTION
See comment thread to #530. This adds a parameter `cachedInitialEvent: true` to `onOpenStart` before passing back a cached result. This mirrors the inclusion of `+rn_cached_initial_event` in the `params` to `onOpenComplete`.