### PR TITLE
Add enableLogging to RNBranch

### DIFF
--- a/ios/RNBranch.h
+++ b/ios/RNBranch.h
@@ -28,6 +28,7 @@ extern NSString * _Nonnull const RNBranchLinkOpenedNotificationLinkPropertiesKey
 + (void)deferInitializationForJSLoad;
 
 + (void)setDebug;
++ (void)enableLogging;
 + (void)delayInitToCheckForSearchAds;
 + (void)setRequestMetadataKey:(NSString * _Nonnull)key value:(NSObject * _Nonnull)value;
 

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -143,6 +143,11 @@ RCT_EXPORT_MODULE();
     [self.branch setDebug];
 }
 
++ (void)enableLogging
+{
+    [self.branch enableLogging];
+}
+
 + (void)delayInitToCheckForSearchAds
 {
     [self.branch delayInitToCheckForSearchAds];


### PR DESCRIPTION
RNBranch had missing `enableLogging` method, which is per docs, the advised way of debugging as `setDebug` got deprecated.

Currently using it through `patch-package` would be glad if it got merged.

Have a nice day!