### PR TITLE
Add getLastAttributedTouchData on JS layer in React Native

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -438,7 +438,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
         branch.getLastAttributedTouchData(new ServerRequestGetLATD.BranchLastAttributedTouchDataListener() {
                 @Override
                 public void onDataFetched(JSONObject jsonObject, BranchError error) {
-                    if (error != null) {
+                    if (error == null) {
                         promise.resolve(jsonObject);
                     } else {
                         promise.reject(GENERIC_ERROR, error.getMessage());

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -433,6 +433,21 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void lastAttributedTouchDataWithAttributionWindow(int window, final Promise promise) {
+        Branch branch = Branch.getInstance();
+        branch.getLastAttributedTouchData(new ServerRequestGetLATD.BranchLastAttributedTouchDataListener() {
+                @Override
+                public void onDataFetched(JSONObject jsonObject, BranchError error) {
+                    if (error != null) {
+                        promise.resolve(jsonObject);
+                    } else {
+                        promise.reject(GENERIC_ERROR, error.getMessage());
+                    }
+                }
+            }, window);
+    }
+
+    @ReactMethod
     public void setIdentity(String identity) {
         Branch branch = Branch.getInstance();
         branch.setIdentity(identity);

--- a/examples/testbed_simple/src/BranchMethods.js
+++ b/examples/testbed_simple/src/BranchMethods.js
@@ -232,8 +232,8 @@ class BranchMethods extends Component {
     const attributionWindow = 365
     try {
       let latd = await branch.lastAttributedTouchDataWithAttributionWindow(attributionWindow)
-        console.log('lastAttributedTouchDataWithAttributionWindow', latd)
-        this.addResult('success', 'lastAttributedTouchDataWithAttributionWindow', latd)
+      console.log('lastAttributedTouchDataWithAttributionWindow', latd)
+      this.addResult('success', 'lastAttributedTouchDataWithAttributionWindow', latd)
     } catch (err) {
       console.log('lastAttributedTouchDataWithAttributionWindow', err)
       this.addResult('error', 'lastAttributedTouchDataWithAttributionWindow', err.toString())

--- a/examples/testbed_simple/src/BranchMethods.js
+++ b/examples/testbed_simple/src/BranchMethods.js
@@ -228,6 +228,18 @@ class BranchMethods extends Component {
     }
   }
 
+  lastAttributedTouchDataWithAttributionWindow = async() => {
+    const attributionWindow = 365
+    try {
+      let latd = await branch.lastAttributedTouchDataWithAttributionWindow(attributionWindow)
+        console.log('lastAttributedTouchDataWithAttributionWindow', latd)
+        this.addResult('success', 'lastAttributedTouchDataWithAttributionWindow', latd)
+    } catch (err) {
+      console.log('lastAttributedTouchDataWithAttributionWindow', err)
+      this.addResult('error', 'lastAttributedTouchDataWithAttributionWindow', err.toString())
+    }
+  }
+
   addResult(type, slug, payload) {
     let result = { type, slug, payload }
     this.setState({
@@ -269,6 +281,7 @@ class BranchMethods extends Component {
           <Button onPress={this.logStandardEvent}>BranchEvent.logEvent (Standard)</Button>
           <Button onPress={this.logCustomEvent}>BranchEvent.logEvent (Custom)</Button>
           <Button onPress={this.openURL}>openURL</Button>
+          <Button onPress={this.lastAttributedTouchDataWithAttributionWindow}>lastAttributedTouchDataWithAttributionWindow</Button>
         </ScrollView>
       </View>
     )

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -402,6 +402,17 @@ RCT_EXPORT_METHOD(
     resolve([self.class.branch getFirstReferringParams]);
 }
 
+#pragma mark lastAttributedTouchDataWithAttributionWindow
+RCT_EXPORT_METHOD(
+                  lastAttributedTouchDataWithAttributionWindow:(NSNumber* __nonnull)window
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejector:(__unused RCTPromiseRejectBlock)reject
+                  ) {
+    [self.class.branch lastAttributedTouchDataWithAttributionWindow:window.integerValue completion:^(BranchLastAttributedTouchData *r){
+        resolve(r);
+    }];
+}
+
 #pragma mark setIdentity
 RCT_EXPORT_METHOD(
                   setIdentity:(NSString *)identity

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,7 @@ class Branch {
   setDebug = () => { throw 'setDebug() is not supported in the RN SDK. For other solutions, please see https://rnbranch.app.link/setDebug' }
   getLatestReferringParams = (synchronous = false) => RNBranch.getLatestReferringParams(synchronous)
   getFirstReferringParams = RNBranch.getFirstReferringParams
+  lastAttributedTouchDataWithAttributionWindow =  (attributionWindow = {}) => RNBranch.lastAttributedTouchDataWithAttributionWindow(attributionWindow)
   setIdentity = (identity) => RNBranch.setIdentity(identity)
   setRequestMetadata = (key, value) => {
     console.info('[Branch] setRequestMetadata has limitations when called from JS.  Some network calls are made prior to the JS layer being available, those calls will not have the metadata.')


### PR DESCRIPTION
Add support for lastAttributedTouchDataWithAttributionWindow. 

This involved adding the method in `RNBranchModule.java` 
```
    @ReactMethod
    public void lastAttributedTouchDataWithAttributionWindow(int window, final Promise promise) {
        Branch branch = Branch.getInstance();
        branch.getLastAttributedTouchData(new ServerRequestGetLATD.BranchLastAttributedTouchDataListener() {
                @Override
                public void onDataFetched(JSONObject jsonObject, BranchError error) {
                    if (error == null) {
                        promise.resolve(jsonObject);
                    } else {
                        promise.reject(GENERIC_ERROR, error.getMessage());
                    }
                }
            }, window);
    }
```

As well as adding the method to support iOS builds in RNBranch.m
```
#pragma mark lastAttributedTouchDataWithAttributionWindow
RCT_EXPORT_METHOD(
                  lastAttributedTouchDataWithAttributionWindow:(NSNumber* __nonnull)window
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejector:(__unused RCTPromiseRejectBlock)reject
                  ) {
    [self.class.branch lastAttributedTouchDataWithAttributionWindow:window.integerValue completion:^(BranchLastAttributedTouchData *r){
        resolve(r);
    }];
}

```
Tested with testbed_simple example project with adding a new button. 