### PR TITLE
SDK-1112 Support promise rejection of iOS latd method

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -408,8 +408,12 @@ RCT_EXPORT_METHOD(
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejector:(__unused RCTPromiseRejectBlock)reject
                   ) {
-    [self.class.branch lastAttributedTouchDataWithAttributionWindow:window.integerValue completion:^(BranchLastAttributedTouchData *r){
-        resolve(r);
+    [self.class.branch lastAttributedTouchDataWithAttributionWindow:window.integerValue completion:^(BranchLastAttributedTouchData *r, NSError *error){
+        if (!error) {
+            resolve(r);
+        } else {
+            reject([NSString stringWithFormat: @"%lu", (long)error.code], error.localizedDescription, error);
+        }
     }];
 }
 


### PR DESCRIPTION
Support promise rejection for the iOS latd method as Android does. This PR is dependent on the release of PS-10 and the iOS SDK PR SDK-1111: https://branch.atlassian.net/browse/SDK-1111 

iOS SDK dependency would have to be updated to support this change with the release that includes SDK-1111