### PR TITLE
lastAttributedTouchData crash on android

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -439,7 +439,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
                 @Override
                 public void onDataFetched(JSONObject jsonObject, BranchError error) {
                     if (error == null) {
-                        promise.resolve(jsonObject);
+                        promise.resolve(convertJsonToMap(jsonObject));
                     } else {
                         promise.reject(GENERIC_ERROR, error.getMessage());
                     }


### PR DESCRIPTION
`lastAttributedTouchData` method call on android is currently resolving `JSONObject` instead of `ReadableMap` which leads to a crash.