### PR TITLE
fix BranchUniversalObject.generateShortUrl type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -286,7 +286,7 @@ interface BranchUniversalObject {
   generateShortUrl: (
     linkProperties: BranchLinkProperties,
     controlParams: BranchLinkControlParams
-  ) => void;
+  ) => Promise<{ url: string }>;
   logEvent: (eventName: string, params?: BranchEventParams) => Promise<null>;
   release: () => void;
 }


### PR DESCRIPTION
BranchUniversalObject.generateShortUrl returns Promise<{url: string}> not void :)