### PR TITLE
Add initSessionTtl to branch interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -293,6 +293,7 @@ interface BranchUniversalObject {
 
 interface Branch {
   subscribe: BranchSubscribe;
+  initSessionTtl?: number;
   skipCachedEvents: () => void;
   disableTracking: (disable: boolean) => void;
   isTrackingDisabled: boolean;


### PR DESCRIPTION
currently if `branch.initSessionTtl` is set typescript will throw an error