### PR TITLE
Update iOS Branch SDK to v1.39.3

### DIFF
--- a/react-native-branch.podspec
+++ b/react-native-branch.podspec
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
   s.source_files = [ "ios/*.h", "ios/*.m"]
   s.compiler_flags = %[-DRNBRANCH_VERSION=@\\"#{s.version}\\"]
   s.header_dir   = 'RNBranch' # also sets generated module name
-  s.dependency 'Branch', '1.39.2'
+  s.dependency 'Branch', '1.39.3'
   s.dependency 'React' # to ensure the correct build order
 end


### PR DESCRIPTION
For picking up changes for:

v1.39.3 CORE-1893 Add timeout to Apple attribution token. Some users are reporting the call can hang.