### PR TITLE
Expose iOS method handleATTAuthorizationStatus to the React Native JS runtime

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -665,4 +665,11 @@ RCT_EXPORT_METHOD(
     [self.universalObjectMap removeObjectForKey:identifier];
 }
 
+#pragma mark handleATTAuthorizationStatus
+RCT_EXPORT_METHOD(
+                  handleATTAuthorizationStatus:(NSUInteger)authorizationStatus
+                  ) {
+    [self.class.branch handleATTAuthorizationStatus:authorizationStatus];
+}
+
 @end

--- a/react-native-branch.podspec
+++ b/react-native-branch.podspec
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
   s.source_files = [ "ios/*.h", "ios/*.m"]
   s.compiler_flags = %[-DRNBRANCH_VERSION=@\\"#{s.version}\\"]
   s.header_dir   = 'RNBranch' # also sets generated module name
-  s.dependency 'Branch', '1.40.0'
+  s.dependency 'Branch', '1.40.2'
   s.dependency 'React' # to ensure the correct build order
 end

--- a/react-native-branch.podspec
+++ b/react-native-branch.podspec
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
   s.source_files = [ "ios/*.h", "ios/*.m"]
   s.compiler_flags = %[-DRNBRANCH_VERSION=@\\"#{s.version}\\"]
   s.header_dir   = 'RNBranch' # also sets generated module name
-  s.dependency 'Branch', '1.40.2'
+  s.dependency 'Branch', '1.40.0'
   s.dependency 'React' # to ensure the correct build order
 end

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -46,6 +46,11 @@ type BranchEventParams = Pick<
   | "customData"
 >;
 
+type ATTAuthorizationStatus = ''
+  | ''
+  | ''
+  | ''
+
 export class BranchEvent {
   logEvent: () => Promise<null>;
   constructor(
@@ -305,6 +310,9 @@ interface Branch {
     identifier: string,
     options: BranchUniversalObjectOptions
   ) => BranchUniversalObject;
+  handleATTAuthorizationStatus: (
+    ATTAuthorizationStatus:ATTAuthorizationStatus
+  ) => void
 }
 declare const branch: Branch;
 export default branch;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -46,22 +46,10 @@ type BranchEventParams = Pick<
   | "customData"
 >;
 
-/**
- * The following ATT responses status were gathered from the following libraries:
- * - https://www.npmjs.com/package/react-native-tracking-transparency
- * - https://docs.expo.dev/versions/latest/sdk/tracking-transparency
- * - https://github.com/zoontek/react-native-permissions
- */
 type ATTAuthorizationStatus = 'authorized'
-  | 'granted'
   | 'denied'
-  | 'notDetermined'
-  | 'not-determined'
   | 'undetermined'
   | 'restricted'
-  | 'limited'
-  | 'unavailable'
-  | 'blocked'
   
 export class BranchEvent {
   logEvent: () => Promise<null>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -46,10 +46,21 @@ type BranchEventParams = Pick<
   | "customData"
 >;
 
+/**
+ * The following ATT responses status were gathered from the following libraries:
+ * - https://www.npmjs.com/package/react-native-tracking-transparency
+ * - https://docs.expo.dev/versions/latest/sdk/tracking-transparency
+ * - https://github.com/zoontek/react-native-permissions
+ */
 type ATTAuthorizationStatus = 'authorized'
+  | 'granted'
   | 'denied'
   | 'notDetermined'
+  | 'not-determined'
+  | 'undetermined'
   | 'restricted'
+  | 'limited'
+  | 'unavailable'
 
 export class BranchEvent {
   logEvent: () => Promise<null>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -46,10 +46,10 @@ type BranchEventParams = Pick<
   | "customData"
 >;
 
-type ATTAuthorizationStatus = ''
-  | ''
-  | ''
-  | ''
+type ATTAuthorizationStatus = 'authorized'
+  | 'denied'
+  | 'notDetermined'
+  | 'restricted'
 
 export class BranchEvent {
   logEvent: () => Promise<null>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -61,7 +61,8 @@ type ATTAuthorizationStatus = 'authorized'
   | 'restricted'
   | 'limited'
   | 'unavailable'
-
+  | 'blocked'
+  
 export class BranchEvent {
   logEvent: () => Promise<null>;
   constructor(

--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,23 @@ class Branch {
       ios: () => RNBranch.openURL(url)
     })()
   }
+  handleATTAuthorizationStatus = (ATTAuthorizationStatus) => {
+    if (Platform.OS != 'ios') return;
+    let normalizedAttAuthorizationStatus = -1
+    if (ATTAuthorizationStatus = 'notDetermined') {
+      normalizedAttAuthorizationStatus = 0;
+    } else if (ATTAuthorizationStatus = 'restricted') {
+      normalizedAttAuthorizationStatus = 1;
+    } else if (ATTAuthorizationStatus = 'denied') {
+      normalizedAttAuthorizationStatus = 2;
+    } else if (ATTAuthorizationStatus = 'authorized') {
+      normalizedAttAuthorizationStatus = 3;
+    } else {
+      throw new Error('[Branch] handleATTAuthorizationStatus expects an argument of "notDetermined", "restricted", "authorized" or "denied"' )
+    }
+
+    RNBranch.handleATTAuthorizationStatus(normalizedAttAuthorizationStatus)
+  }
 
   /*** BranchUniversalObject ***/
   createBranchUniversalObject = createBranchUniversalObject

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,7 @@ class Branch {
         normalizedAttAuthorizationStatus = 3;
         break;
       case 'denied':
+      case 'blocked':
         normalizedAttAuthorizationStatus = 2;
         break;
       case 'notDetermined':

--- a/src/index.js
+++ b/src/index.js
@@ -90,27 +90,21 @@ class Branch {
 
     switch(ATTAuthorizationStatus) {
       case 'authorized':
-      case 'granted':
         normalizedAttAuthorizationStatus = 3;
         break;
       case 'denied':
-      case 'blocked':
         normalizedAttAuthorizationStatus = 2;
         break;
-      case 'notDetermined':
-      case 'not-determined':
       case 'undetermined':
         normalizedAttAuthorizationStatus = 0;
         break;
       case 'restricted':
-      case 'unavailable':
-      case 'limited':
         normalizedAttAuthorizationStatus = 1;
         break;
     }
 
     if (normalizedAttAuthorizationStatus < 0) {
-      console.info('[Branch] handleATTAuthorizationStatus received an unrecognized value')
+      console.info('[Branch] handleATTAuthorizationStatus received an unrecognized value. Value must be one of; authorized, denied, undetermined, or restricted')
       return;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -87,16 +87,30 @@ class Branch {
   handleATTAuthorizationStatus = (ATTAuthorizationStatus) => {
     if (Platform.OS != 'ios') return;
     let normalizedAttAuthorizationStatus = -1
-    if (ATTAuthorizationStatus = 'notDetermined') {
-      normalizedAttAuthorizationStatus = 0;
-    } else if (ATTAuthorizationStatus = 'restricted') {
-      normalizedAttAuthorizationStatus = 1;
-    } else if (ATTAuthorizationStatus = 'denied') {
-      normalizedAttAuthorizationStatus = 2;
-    } else if (ATTAuthorizationStatus = 'authorized') {
-      normalizedAttAuthorizationStatus = 3;
-    } else {
-      throw new Error('[Branch] handleATTAuthorizationStatus expects an argument of "notDetermined", "restricted", "authorized" or "denied"' )
+
+    switch(ATTAuthorizationStatus) {
+      case 'authorized':
+      case 'granted':
+        normalizedAttAuthorizationStatus = 3;
+        break;
+      case 'denied':
+        normalizedAttAuthorizationStatus = 2;
+        break;
+      case 'notDetermined':
+      case 'not-determined':
+      case 'undetermined':
+        normalizedAttAuthorizationStatus = 0;
+        break;
+      case 'restricted':
+      case 'unavailable':
+      case 'limited':
+        normalizedAttAuthorizationStatus = 1;
+        break;
+    }
+
+    if (normalizedAttAuthorizationStatus < 0) {
+      console.info('[Branch] handleATTAuthorizationStatus received an unrecognized value')
+      return;
     }
 
     RNBranch.handleATTAuthorizationStatus(normalizedAttAuthorizationStatus)


### PR DESCRIPTION
The react-native-branch library doesn't have the ability to record the ATT Opt-in or Opt-out status. This PR exposes the Branch SDK method `handleATTAuthorizationStatus` to the React Native runtime so that developers using Branch can track the ATT Opt-In event without having to develop native code.

Here is the TypeScript definition of the exposed method. `handleATTAuthorizationStatus` is meant to be called after prompting for the ATT (variety of 3rd party libraries available). The single argument is meant to have a value of either 'authorized', 'denied', 'undetermined', or 'restricted'. Other arguments will have no effect other than logging the error as a console warning.
```
  type ATTAuthorizationStatus = 'authorized' | 'denied' | 'undetermined' | 'restricted'
  function handleATTAuthorizationStatus(ATTAuthorizationStatus:ATTAuthorizationStatus) => void
```

Here are some example implementations using popular 3rd party ATT tracking libraries for react-native.

An example implementation using `expo-tracking-transparency`
```
import { getTrackingPermissionsAsync, requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
import Branch from 'react-native-branch';

async function PromptATTAndCollectOptInStatus() {
  const permissionResponse = await getTrackingPermissionsAsync();
 
  // expo-tracking-transparency uses three states; undetermined, granted, and denied
  // if the status is granted or denied we do not need to prompt and can exit early
  if (permissionResponse.status !== 'undetermined') return;

  // request the ATT prompt
  const attPermissionResponse = await requestTrackingPermissionsAsync();

  // normalize the response status from expo-tracking-transparency to a status known by Branch. 
  // in the case of expo-tracking-transparency, 'granted' needs to be converted to 'authorized'
  if (promptResponseStatus === 'granted') {
    promptResponseStatus = 'authorized';
  }

  // send the result to branch
  Branch.handleATTAuthorizationStatus(requestedPermissionsResponse.status);
}
```

An example implementation using `react-native-tracking-transparency`
```
import { getTrackingStatus, requestTrackingPermission } from 'react-native-tracking-transparency';
import Branch from 'react-native-branch';

async function PromptATTAndCollectOptInStatus() {
  const trackingStatus = await getTrackingStatus();
 
  // react-native-tracking-transparency uses five states; unavailable, authorized, denied, restricted, and not-determined
  // if the status is unavailable, restircted, or not-determiend we can exit early
  if (trackingStatus === 'unavailable' || trackingStatus === 'not-determined' || 'restricted') return;
  
  // request the ATT prompt
  let requestedTrackingStatus = await requestTrackingPermission();

  // normalize the response status from react-native-tracking-transparency to a status known by Branch. 
  // in the case of react-native-tracking-transparency, 'unavailable' and 'not-determined' are converted to 'undetermined'
  if (requestedTrackingStatus === 'unavailable' || requestedTrackingStatus === 'not-determined) {
    requestedTrackingStatus = 'undetermined'
  }

  // pass the result to Branch
  Branch.handleATTAuthorizationStatus(requestedTrackingStatus);
}
```