### PR TITLE
Add checks for listeners remove calls

### DIFF
--- a/src/BranchSubscriber.js
+++ b/src/BranchSubscriber.js
@@ -118,12 +118,18 @@ export default class BranchSubscriber {
     this._subscribed = false
 
     if (this.options.onOpenStart) {
-      this.initSessionStart.remove()
+      if (this.initSessionStart) {
+        this.initSessionStart.remove()
+      };
     }
 
     if (this.options.onOpenComplete) {
-      this.initSessionSuccess.remove()
-      this.initSessionError.remove()
+      if (this.initSessionSuccess) {
+        this.initSessionSuccess.remove();
+      }
+      if (this.initSessionError) {
+        this.initSessionError.remove()
+      }
     }
   }
 }


### PR DESCRIPTION
Required fixes for #681.

It is necessary to check against `null` to prevent crashes because sometimes the properties might be null, e.g. because of Fast Refresh or re-rendering.