### PR TITLE
Fix createBranchUniversalObject's TypeScript definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -309,7 +309,7 @@ interface Branch {
   createBranchUniversalObject: (
     identifier: string,
     options: BranchUniversalObjectOptions
-  ) => BranchUniversalObject;
+  ) => Promise<BranchUniversalObject>;
   handleATTAuthorizationStatus: (
     ATTAuthorizationStatus:ATTAuthorizationStatus
   ) => void


### PR DESCRIPTION
createBranchUniversalObject is an async function, so it's TypeScript definition should be a function that returns `Promise<BranchUniversalObject>` instead of `BranchUniversalObject`.