### PR TITLE
Fix BranchUniversalObject showShareSheet return type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -276,13 +276,25 @@ interface BranchLinkControlParams {
   $samsung_url?: string;
 }
 
+interface BranchShareSuccess {
+  completed: true;
+  error: null;
+  channel: string;
+}
+
+interface BranchShareFailure {
+  completed: false;
+  error: null | string;
+  channel: null;
+}
+
 interface BranchUniversalObject {
   ident: string;
   showShareSheet: (
     shareOptions?: BranchShareSheetOptions,
     linkProperties?: BranchLinkProperties,
     controlParams?: BranchLinkControlParams
-  ) => void;
+  ) => Promise<BranchShareSuccess | BranchShareFailure>;
   generateShortUrl: (
     linkProperties: BranchLinkProperties,
     controlParams: BranchLinkControlParams


### PR DESCRIPTION
_showShareSheet_ method in BranchUniversalObject has incorrect return type. It indicates that function is sync and returns void. When function is async and returns Promise with a result.