### PR TITLE
Change ~creation_source type to be a number

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,7 +17,7 @@ export interface BranchParams {
   "~tags"?: string[];
   "~campaign"?: string;
   "~stage"?: string;
-  "~creation_source"?: string;
+  "~creation_source"?: number;
   "~referring_link"?: string;
   "~id"?: string;
   "+match_guaranteed": boolean;


### PR DESCRIPTION
Fixes #709

I've tested locally by changing the type manually within `node_modules` folder but you might want to run an e2e or integration test to confirm it doesn't break anything.