### PR TITLE
Release 5.4.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+2022-06-06 Version 5.4.1
+  - Update Android SDK to 5.1.5
+  - Update iOS SDK to 1.42.0
+
 2022-02-10 Version 5.4.0
   - Fix type definition of createBranchUniversalObject (Thanks v-fernandez!)
   - Update Android SDK to 5.1.0

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,5 +32,5 @@ android {
 dependencies {
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation 'com.facebook.react:react-native:+' // From node_modules
-    api 'io.branch.sdk.android:library:5.1.0'
+    api 'io.branch.sdk.android:library:5.1.5'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-branch",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Branch Metrics React Native SDK",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/react-native-branch.podspec
+++ b/react-native-branch.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.source_files = [ "ios/*.h", "ios/*.m"]
   s.compiler_flags = %[-DRNBRANCH_VERSION=@\\"#{s.version}\\"]
   s.header_dir   = 'RNBranch' # also sets generated module name
-  s.dependency 'Branch', '1.41.0'
+  s.dependency 'Branch', '1.42.0'
   s.dependency 'React-Core' # to ensure the correct build order
   
   # Swift/Objective-C compatibility


### PR DESCRIPTION
[SDK-1442] React Native - Patch release 5.4.1 to pick up Branch Android SDK 5.1.5

- Update Android SDK to 5.1.5
- Update iOS SDK to 1.42.0

https://github.com/BranchMetrics/android-branch-deep-linking-attribution/compare/5.1.0...5.1.5
https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/compare/1.41.0...1.42.0

[SDK-1442]: https://branch.atlassian.net/browse/SDK-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ