### PR TITLE
[SDK-1562] Add callback to setIdentity

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -446,13 +446,13 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
    @ReactMethod
-    public void setIdentityWithPromise(String identity, Promise promise) {
+    public void setIdentityAsync(String identity, Promise promise) {
         Branch branch = Branch.getInstance();
         branch.setIdentity(identity, new BranchReferralInitListener() {
             @Override
             public void onInitFinished(JSONObject referringParams, BranchError error) {
                 if (error != null) {
-                    promise.reject("RNBranch::Error::setIdentityWithPromise failed", error.getMessage());
+                    promise.reject("RNBranch::Error::setIdentityAsync failed", error.getMessage());
                 } else {
                     promise.resolve(convertJsonToMap(referringParams));
                 }

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -443,16 +443,16 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     public void setIdentity(String identity, Promise promise) {
         Branch branch = Branch.getInstance();
 
-          branch.setIdentity(identity, new BranchReferralInitListener() {
-                    @Override
-                    public void onInitFinished(JSONObject referringParams, BranchError error) {
-                        if (error != null) {
-                            promise.reject("RNBranch::Error::setIdentity failed", error.getMessage());
-                        } else {
-                            promise.resolve(convertJsonToMap(branch.getFirstReferringParams()));
-                        }
-                    }
-                });
+        branch.setIdentity(identity, new BranchReferralInitListener() {
+            @Override
+            public void onInitFinished(JSONObject referringParams, BranchError error) {
+                if (error != null) {
+                    promise.reject("RNBranch::Error::setIdentity failed", error.getMessage());
+                } else {
+                    promise.resolve(convertJsonToMap(convertJsonToMap(referringParams)));
+                }
+            }
+        });
     }
 
     @ReactMethod

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -440,16 +440,21 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setIdentity(String identity, Promise promise) {
+    public void setIdentity(String identity) {
         Branch branch = Branch.getInstance();
+        branch.setIdentity(identity);
+    }
 
+   @ReactMethod
+    public void setIdentityWithPromise(String identity, Promise promise) {
+        Branch branch = Branch.getInstance();
         branch.setIdentity(identity, new BranchReferralInitListener() {
             @Override
             public void onInitFinished(JSONObject referringParams, BranchError error) {
                 if (error != null) {
-                    promise.reject("RNBranch::Error::setIdentity failed", error.getMessage());
+                    promise.reject("RNBranch::Error::setIdentityWithPromise failed", error.getMessage());
                 } else {
-                    promise.resolve(convertJsonToMap(convertJsonToMap(referringParams)));
+                    promise.resolve(convertJsonToMap(referringParams));
                 }
             }
         });

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -440,9 +440,10 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setIdentity(String identity) {
+    public void setIdentity(String identity, Promise promise) {
         Branch branch = Branch.getInstance();
         branch.setIdentity(identity);
+        promise.resolve(convertJsonToMap(branch.getFirstReferringParams()));
     }
 
     @ReactMethod

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -442,8 +442,17 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void setIdentity(String identity, Promise promise) {
         Branch branch = Branch.getInstance();
-        branch.setIdentity(identity);
-        promise.resolve(convertJsonToMap(branch.getFirstReferringParams()));
+
+          branch.setIdentity(identity, new BranchReferralInitListener() {
+                    @Override
+                    public void onInitFinished(JSONObject referringParams, BranchError error) {
+                        if (error != null) {
+                            promise.reject("RNBranch::Error::setIdentity failed", error.getMessage());
+                        } else {
+                            promise.resolve(convertJsonToMap(branch.getFirstReferringParams()));
+                        }
+                    }
+                });
     }
 
     @ReactMethod

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -407,9 +407,9 @@ RCT_EXPORT_METHOD(
     [self.class.branch setIdentity:identity];
 }
 
-#pragma mark setIdentityWithPromise
+#pragma mark setIdentityAsync
 RCT_EXPORT_METHOD(
-                  setIdentityWithPromise:(NSString *)identity
+                  setIdentityAsync:(NSString *)identity
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject
                   ) {
@@ -417,7 +417,7 @@ RCT_EXPORT_METHOD(
         if (!error) {
             resolve(params);
         } else {
-            reject(@"RNBranch::Error::setIdentityWithPromise failed", error.localizedDescription, error);
+            reject(@"RNBranch::Error::setIdentityAsync failed", error.localizedDescription, error);
         }
     }];
 }

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -410,8 +410,7 @@ RCT_EXPORT_METHOD(
         if (!error) {
             resolve([self.class.branch getFirstReferringParams]);
         } else {
-            reject(@"RNBranch::Error", error.localizedDescription, error);
-
+            reject(@"RNBranch::Error::setIdentity failed", error.localizedDescription, error);
         }
     }
 }

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -403,16 +403,23 @@ RCT_EXPORT_METHOD(
 #pragma mark setIdentity
 RCT_EXPORT_METHOD(
                   setIdentity:(NSString *)identity
+                  ) {
+    [self.class.branch setIdentity:identity];
+}
+
+#pragma mark setIdentityWithPromise
+RCT_EXPORT_METHOD(
+                  setIdentityWithPromise:(NSString *)identity
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject
                   ) {
     [self.class.branch setIdentity: identity withCallback:^(NSDictionary *params, NSError *error) {
         if (!error) {
-            resolve([self.class.branch getFirstReferringParams]);
+            resolve(params);
         } else {
-            reject(@"RNBranch::Error::setIdentity failed", error.localizedDescription, error);
+            reject(@"RNBranch::Error::setIdentityWithPromise failed", error.localizedDescription, error);
         }
-    }
+    }];
 }
 
 #pragma mark setRequestMetadataKey

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -403,8 +403,17 @@ RCT_EXPORT_METHOD(
 #pragma mark setIdentity
 RCT_EXPORT_METHOD(
                   setIdentity:(NSString *)identity
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(__unused RCTPromiseRejectBlock)reject
                   ) {
-    [self.class.branch setIdentity:identity];
+    [self.class.branch setIdentity: identity withCallback:^(NSDictionary *params, NSError *error) {
+        if (!error) {
+            resolve([self.class.branch getFirstReferringParams]);
+        } else {
+            reject(@"RNBranch::Error", error.localizedDescription, error);
+
+        }
+    }
 }
 
 #pragma mark setRequestMetadataKey

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -309,7 +309,7 @@ interface Branch {
   getLatestReferringParams: (synchronous?: boolean) => Promise<BranchParams>;
   getFirstReferringParams: () => Promise<BranchParams>;
   lastAttributedTouchData: (attributionWindow?: number) => Promise<BranchParams>;
-  setIdentity: (identity: string) => void;
+  setIdentity: (identity: string) => Promise<BranchParams>;
   setRequestMetadata: (key: string, value: string) => void;
   addFacebookPartnerParameter: (name: string, value: string) => void;
   clearPartnerParameter: () => void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -310,7 +310,7 @@ interface Branch {
   getFirstReferringParams: () => Promise<BranchParams>;
   lastAttributedTouchData: (attributionWindow?: number) => Promise<BranchParams>;
   setIdentity: (identity: string) => void;
-  setIdentityWithPromise: (identity: string) => Promise<BranchParams>;
+  setIdentityAsync: (identity: string) => Promise<BranchParams>;
   setRequestMetadata: (key: string, value: string) => void;
   addFacebookPartnerParameter: (name: string, value: string) => void;
   clearPartnerParameter: () => void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -309,7 +309,8 @@ interface Branch {
   getLatestReferringParams: (synchronous?: boolean) => Promise<BranchParams>;
   getFirstReferringParams: () => Promise<BranchParams>;
   lastAttributedTouchData: (attributionWindow?: number) => Promise<BranchParams>;
-  setIdentity: (identity: string) => Promise<BranchParams>;
+  setIdentity: (identity: string) => void;
+  setIdentityWithPromise: (identity: string) => Promise<BranchParams>;
   setRequestMetadata: (key: string, value: string) => void;
   addFacebookPartnerParameter: (name: string, value: string) => void;
   clearPartnerParameter: () => void;

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ class Branch {
   getFirstReferringParams = RNBranch.getFirstReferringParams
   lastAttributedTouchData =  (attributionWindow = {}) => RNBranch.lastAttributedTouchData(attributionWindow)
   setIdentity = (identity) => RNBranch.setIdentity(identity)
-  setIdentityWithPromise = (identity) => RNBranch.setIdentityWithPromise(identity)
+  setIdentityAsync = (identity) => RNBranch.setIdentityAsync(identity)
   setRequestMetadata = (key, value) => {
     console.info('[Branch] setRequestMetadata has limitations when called from JS.  Some network calls are made prior to the JS layer being available, those calls will not have the metadata.')
     return RNBranch.setRequestMetadataKey(key, value)

--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,7 @@ class Branch {
   getFirstReferringParams = RNBranch.getFirstReferringParams
   lastAttributedTouchData =  (attributionWindow = {}) => RNBranch.lastAttributedTouchData(attributionWindow)
   setIdentity = (identity) => RNBranch.setIdentity(identity)
+  setIdentityWithPromise = (identity) => RNBranch.setIdentityWithPromise(identity)
   setRequestMetadata = (key, value) => {
     console.info('[Branch] setRequestMetadata has limitations when called from JS.  Some network calls are made prior to the JS layer being available, those calls will not have the metadata.')
     return RNBranch.setRequestMetadataKey(key, value)


### PR DESCRIPTION
### Description
Adds a new method, `setIdentityWithPromise`, which sets the identity/developer_identity and has a promise with returns the first referring params. There already is a `setIdentity` functions which works the same and will still exist. However, it is void/does not return, which is why adding a new method which does.

The native SDKs have two versions of setIdentity, one with a callback and one thats void. This new method uses the one with a callback.

### Usage/Examples
**Existing `setIdentity()`**
```
branch.setIdentity("user123")
```

**New `setIdentityWithPromise()`**
```
let result = branch.setIdentityWithPromise("user456");
    result.then((params) => {
      console.log('setIdentityWithPromise Result: ', params)
});
```