### PR TITLE
[SDK-1517] [ReactNative] customData in track event crash if it's not string

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -773,7 +773,14 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
             ReadableMapKeySetIterator it = customData.keySetIterator();
             while (it.hasNextKey()) {
                 String key = it.nextKey();
-                event.addCustomDataProperty(key, customData.getString(key));
+                
+                ReadableType readableType = customData.getType(key);
+                if(readableType == ReadableType.String) {
+                    event.addCustomDataProperty(key, customData.getString(key));
+                }
+                else{
+                    Log.w(REACT_CLASS, "customData values must be strings. Value for property " + key + " is not a string type.");
+                }
             }
         }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -71,7 +71,7 @@ export class BranchEvent {
   description?: string;
   searchQuery?: string;
   alias?: string;
-  customData?: Record<string, AnyDataType>;
+  customData?: Record<string, string>;
 
   /**
    * Standard Add to Cart event


### PR DESCRIPTION
An issue was raised https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution/issues/725 wherein calling a `BranchEvent` with `customParams` with non-string values would throw an uncaught exception. 

After review, we decided to define the typing as  
 `customData?: Record<string, string>;`

This typing will avoid the mismatch in the native layer.

To test, install the beta containing this change.
https://www.npmjs.com/package/react-native-branch/v/5.6.0-beta.0
via
`npm install — save react-native-branch@beta`