### PR TITLE
[INTENG-16718] Fixed LATD not being returned on iOS

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -394,9 +394,13 @@ RCT_EXPORT_METHOD(
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject
                   ) {
-    [self.class.branch lastAttributedTouchDataWithAttributionWindow:window.integerValue completion:^(BranchLastAttributedTouchData *r, NSError *e){
-        // TODO: pass back the error to JS
-        resolve(r);
+    [self.class.branch lastAttributedTouchDataWithAttributionWindow:window.integerValue completion:^(BranchLastAttributedTouchData *data, NSError *error){
+        if (!error) {
+            resolve(data.lastAttributedTouchJSON);
+        } else {
+            reject(@"RNBranch::Error::lastAttributedTouchData failed", error.localizedDescription, error);
+        }
+
     }];
 }
 


### PR DESCRIPTION
## Reference
INTENG-16718 -- lastAttributedTouchData does not return the data at JS level 

## Summary
A client reported that they were not able to get the LATD in React Native iOS. We found that the server request was being made and the data was received, but the LATD would still return as undefined. This PR features a fix for that problem and adds error handling to the `lastAttributedTouchData` function.

## Motivation
The issue was in RNBranch.m. The LATD data was being returned as BranchLastAttributedTouchData but needed to be resolved as BranchLastAttributedTouchData.lastAttributedTouchJSON. 

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
To test, make sure you have LATD available in your React Native iOS app. Then run the lastAttributedTouchData function and log the result. It should show the proper LATD data.
```
let latd = await branch.lastAttributedTouchData(attributionWindow)
console.log('Success - lastAttributedTouchData: ', latd)
```


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->