### PR TITLE
Fix setIdentityAsync parameter

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -446,7 +446,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
    @ReactMethod
-    public void setIdentityAsync(String identity, Promise promise) {
+    public void setIdentityAsync(String identity, final Promise promise) {
         Branch branch = Branch.getInstance();
         branch.setIdentity(identity, new Branch.BranchReferralInitListener() {
             @Override


### PR DESCRIPTION
## Reference
SDK-1662 - [Android] error: local variable promise is accessed from within inner class; needs to be declared final

## Summary
Issue https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution/issues/746 was raised noting that there was a compile error when trying to build with the latest package. The solution is to add the `final` modifier over the Promise which gets referenced in an inner class inside `public void setIdentityAsync`. 

This is consistent with the rest of the project's patterns.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Checkout branch and reference locally. You should see no compile errors.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->