### PR TITLE
Fix BranchUniversalObject#generateShortUrl parameter type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -296,8 +296,8 @@ interface BranchUniversalObject {
     controlParams?: BranchLinkControlParams
   ) => Promise<BranchShareSuccess | BranchShareFailure>;
   generateShortUrl: (
-    linkProperties: BranchLinkProperties,
-    controlParams: BranchLinkControlParams
+    linkProperties?: BranchLinkProperties,
+    controlParams?: BranchLinkControlParams
   ) => Promise<{ url: string }>;
   logEvent: (eventName: string, params?: BranchEventParams) => Promise<null>;
   release: () => void;


### PR DESCRIPTION
I modified it to be closer to the requirements of the actual js code. All arguments have default values, so it seemed right to give them as optionals.

https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution/blob/dfa570b073c4fddba189a1604382f0093f514059/src/branchUniversalObject.js#L74