### PR TITLE
[SDK-1596] RN invoke IOS notifyNativeToInit

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -448,6 +448,13 @@ RCT_EXPORT_METHOD(
     [self.class.branch handleDeepLinkWithNewSession:[NSURL URLWithString:urlString]];
 }
 
+#pragma mark notifyNativeToInit
+RCT_EXPORT_METHOD(
+                  notifyNativeToInit
+                  ) {
+    [self.class.branch notifyNativeToInit];
+}
+
 #pragma mark sendCommerceEvent
 RCT_EXPORT_METHOD(
                   sendCommerceEvent:(NSString *)revenue

--- a/react-native-branch.podspec
+++ b/react-native-branch.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.source_files = [ "ios/*.h", "ios/*.m"]
   s.compiler_flags = %[-DRNBRANCH_VERSION=@\\"#{s.version}\\"]
   s.header_dir   = 'RNBranch' # also sets generated module name
-  s.dependency 'Branch', '1.45.2'
+  s.dependency 'Branch', '2.1.0'
   s.dependency 'React-Core' # to ensure the correct build order
   
   # Swift/Objective-C compatibility

--- a/src/index.js
+++ b/src/index.js
@@ -45,8 +45,8 @@ class Branch {
     subscriber.subscribe()
 
     Platform.select({
-      android: () => RNBranch.notifyNativeToInit()
-      //ios: () => RNBranch.notifyNativeToInit() //TODO: implement iOS side
+      android: () => RNBranch.notifyNativeToInit(),
+      ios: () => RNBranch.notifyNativeToInit()
     })
 
     return () => subscriber.unsubscribe()


### PR DESCRIPTION
## Reference
SDK-1596

## Summary
adds RN code which invokes IOS native method `notifyNativeToInit` https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/blob/fde54230cd76719d1f57b9d108eb4ca513ccc1c6/BranchSDK/Branch.m#L2164 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
