### PR TITLE
[SDK-1990] Update iOS and Android SDK versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,5 @@ def safeExtGet(prop, fallback) {
 dependencies {
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation 'com.facebook.react:react-native:+' // From node_modules
-    api 'io.branch.sdk.android:library:5.3.0'
+    api 'io.branch.sdk.android:library:5.5.0'
 }

--- a/branch.example.json
+++ b/branch.example.json
@@ -3,6 +3,5 @@
     "liveKey": "key_live_xxxx",
     "testKey": "key_test_yyyy",
     "useTestInstance": true,
-    "delayInitToCheckForSearchAds": true,
     "enableFacebookLinkCheck": true
 }

--- a/branchreactnativetestbed/package.json
+++ b/branchreactnativetestbed/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-native": "0.71.4",
-    "react-native-branch": "^5.8.0-alpha.2"
+    "react-native-branch": "^5.9.0-alpha.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/docs/branch.json.md
+++ b/docs/branch.json.md
@@ -56,26 +56,22 @@ It is possible to include different versions of the configuration for debug and 
 builds as well as for iOS and Android. The following files will be used, in order.
 
 ### Android debug
-
 - branch.android.debug.json
 - branch.debug.json
 - branch.android.json
 - branch.json
 
 ### Android release
-
 - branch.android.json
 - branch.json
 
 ### iOS debug
-
 - branch.ios.debug.json
 - branch.debug.json
 - branch.ios.json
 - branch.json
 
 ### iOS release
-
 - branch.ios.json
 - branch.json
 

--- a/docs/branch.json.md
+++ b/docs/branch.json.md
@@ -56,22 +56,26 @@ It is possible to include different versions of the configuration for debug and 
 builds as well as for iOS and Android. The following files will be used, in order.
 
 ### Android debug
+
 - branch.android.debug.json
 - branch.debug.json
 - branch.android.json
 - branch.json
 
 ### Android release
+
 - branch.android.json
 - branch.json
 
 ### iOS debug
+
 - branch.ios.debug.json
 - branch.debug.json
 - branch.ios.json
 - branch.json
 
 ### iOS release
+
 - branch.ios.json
 - branch.json
 
@@ -96,15 +100,14 @@ of `branch.json`.
 Note that support for setting Branch keys on Android in branch.json requires
 version 3.x of react-native-branch, using [RNBranchModule.getAutoInstance()](https://help.branch.io/developers-hub/docs/react-native#section-updating-from-an-earlier-version-or-starting-with-v-3-0-0)
 
-|key|description|type|
-|---|---|---|
-|branchKey|The Branch key to use. Overrides liveKey, testKey and useTestInstance.|String|
-|liveKey|The live Branch key to use if useTestInstance is false. Ignored if useTestInstance is true or branchKey is present.|String|
-|debugMode|If true, `setDebug` will be called in the native SDK, enabling testing of install events.|Boolean|
-|delayInitToCheckForSearchAds|If true, `delayInitToCheckForSearchAds` will be called on the iOS Branch instance. Ignored on Android.|Boolean|
-|enableFacebookLinkCheck|If true, results in calling `enableFacebookAppLinkCheck()` in the Branch Android SDK and `registerFacebookDeepLinkingClass:` in the Branch iOS SDK.|Boolean|
-|testKey|The test Branch key to use if useTestInstance is true. Ignored if useTestInstance is false or branchKey is present.|String|
-|useTestInstance|Determines whether liveKey or testKey is used if branchKey is not present.|Boolean|
+| key                     | description                                                                                                                                         | type    |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| branchKey               | The Branch key to use. Overrides liveKey, testKey and useTestInstance.                                                                              | String  |
+| liveKey                 | The live Branch key to use if useTestInstance is false. Ignored if useTestInstance is true or branchKey is present.                                 | String  |
+| debugMode               | If true, `setDebug` will be called in the native SDK, enabling testing of install events.                                                           | Boolean |
+| enableFacebookLinkCheck | If true, results in calling `enableFacebookAppLinkCheck()` in the Branch Android SDK and `registerFacebookDeepLinkingClass:` in the Branch iOS SDK. | Boolean |
+| testKey                 | The test Branch key to use if useTestInstance is true. Ignored if useTestInstance is false or branchKey is present.                                 | String  |
+| useTestInstance         | Determines whether liveKey or testKey is used if branchKey is not present.                                                                          | Boolean |
 
 ## Example
 
@@ -116,7 +119,6 @@ See [branch.example.json](https://github.com/BranchMetrics/react-native-branch-d
   "liveKey": "key_live_xxxx",
   "testKey": "key_test_yyyy",
   "useTestInstance": true,
-  "delayInitToCheckForSearchAds": true,
   "enableFacebookLinkCheck": true
 }
 ```

--- a/ios/RNBranch.h
+++ b/ios/RNBranch.h
@@ -31,6 +31,5 @@ extern NSString * _Nonnull const RNBranchLinkOpenedNotificationLinkPropertiesKey
 
 + (void)setDebug;
 + (void)enableLogging;
-+ (void)delayInitToCheckForSearchAds;
 
 @end

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -119,11 +119,6 @@ RCT_EXPORT_MODULE();
     [self.branch enableLogging];
 }
 
-+ (void)delayInitToCheckForSearchAds
-{
-    [self.branch delayInitToCheckForSearchAds];
-}
-
 + (void)useTestInstance {
     useTestInstance = YES;
 }

--- a/react-native-branch.podspec
+++ b/react-native-branch.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.source_files = [ "ios/*.h", "ios/*.m"]
   s.compiler_flags = %[-DRNBRANCH_VERSION=@\\"#{s.version}\\"]
   s.header_dir   = 'RNBranch' # also sets generated module name
-  s.dependency 'BranchSDK', '2.1.0'
+  s.dependency 'BranchSDK', '2.2.0'
   s.dependency 'React-Core' # to ensure the correct build order
   
   # Swift/Objective-C compatibility


### PR DESCRIPTION
## Reference
SDK-1990 -- Bump iOS and Android versions

## Summary
Bumped the iOS and Android native SDK versions. Also, the latest iOS SDK removed some deprecated Apple Search Ads code, so the respective code was removed here as well.

**iOS: 2.1.0 -> 2.2.0
Android: 5.3.0 -> 5.5.0**

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To provide React Native clients access to the latest iOS and Android features.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Try out the latest alpha package (5.9.0-alpha.3) in the testbed app and ensure all functionality is working correctly.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
