### PR TITLE
[SDK-2137] Use working directory for automation test

### DIFF
--- a/branch-sdk-automation-testbed/package-lock.json
+++ b/branch-sdk-automation-testbed/package-lock.json
@@ -8,19 +8,23 @@
       "name": "branch_sdk_react_native_app",
       "version": "0.0.1",
       "dependencies": {
+        "@react-native-community/push-notification-ios": "^1.10.1",
         "@react-navigation/native": "^6.0.11",
         "@react-navigation/native-stack": "^6.7.0",
         "@react-navigation/stack": "^6.2.2",
         "@types/react-native-push-notification": "^8.1.1",
         "react": "18.0.0",
         "react-native": "0.69.1",
-        "react-native-branch": "^5.5.0",
+        "react-native-branch": "file:..",
         "react-native-dropdown-picker": "^5.4.2",
         "react-native-json-tree": "^1.3.0",
+        "react-native-keyboard-aware-scroll-view": "^0.9.5",
         "react-native-modal": "^13.0.1",
+        "react-native-pager-view": "^5.4.25",
         "react-native-push-notification": "^8.1.1",
         "react-native-safe-area-context": "^4.3.1",
         "react-native-screens": "^3.15.0",
+        "react-native-tab-view": "^3.1.1",
         "react-native-webview": "^11.23.0"
       },
       "devDependencies": {
@@ -39,6 +43,25 @@
         "metro-react-native-babel-preset": "^0.70.3",
         "react-test-renderer": "18.0.0",
         "typescript": "^4.4.4"
+      }
+    },
+    "..": {
+      "version": "5.9.2",
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/core": "^7.20.0",
+        "@babel/preset-env": "^7.20.0",
+        "@babel/runtime": "^7.20.0",
+        "@react-native-community/eslint-config": "^3.0.0",
+        "babel-jest": "^29.2.1",
+        "eslint": "^8.19.0",
+        "eslint-config-rackt": "^1.1.1",
+        "jest": "^29.2.1",
+        "react": "18.2.0",
+        "react-native": "0.71.4"
+      },
+      "peerDependencies": {
+        "react-native": ">= 0.60"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4181,7 +4204,6 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/push-notification-ios/-/push-notification-ios-1.10.1.tgz",
       "integrity": "sha512-k6bZWUKLif4GjenyTD3aQLwA2VT3bNmt22INO/34lexnpmqkPDZF7nreqbckTHG0Zso9wDTe4N/AZJUC/d8iRg==",
-      "peer": true,
       "dependencies": {
         "invariant": "^2.2.4"
       },
@@ -13103,12 +13125,8 @@
       }
     },
     "node_modules/react-native-branch": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/react-native-branch/-/react-native-branch-5.5.0.tgz",
-      "integrity": "sha512-f1kv/+tVyqPPKKobstcS8CO2u9PIZBgMDFsSPPrPZP6AZm1FyYDrifbdpJRRbfyky/fApEUNBgl0ZAC+ABPQyA==",
-      "peerDependencies": {
-        "react-native": ">= 0.60"
-      }
+      "resolved": "..",
+      "link": true
     },
     "node_modules/react-native-codegen": {
       "version": "0.69.1",
@@ -13152,6 +13170,14 @@
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz",
       "integrity": "sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g=="
     },
+    "node_modules/react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "peerDependencies": {
+        "react-native": ">=0.42.0"
+      }
+    },
     "node_modules/react-native-json-tree": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-native-json-tree/-/react-native-json-tree-1.3.0.tgz",
@@ -13165,6 +13191,18 @@
         "react-native": ">=0.43.2"
       }
     },
+    "node_modules/react-native-keyboard-aware-scroll-view": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.5.tgz",
+      "integrity": "sha512-XwfRn+T/qBH9WjTWIBiJD2hPWg0yJvtaEw6RtPCa5/PYHabzBaWxYBOl0usXN/368BL1XktnZPh8C2lmTpOREA==",
+      "dependencies": {
+        "prop-types": "^15.6.2",
+        "react-native-iphone-x-helper": "^1.0.3"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.48.4"
+      }
+    },
     "node_modules/react-native-modal": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-13.0.1.tgz",
@@ -13176,6 +13214,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": ">=0.65.0"
+      }
+    },
+    "node_modules/react-native-pager-view": {
+      "version": "5.4.25",
+      "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-5.4.25.tgz",
+      "integrity": "sha512-3drrYwaLat2fYszymZe3nHMPASJ4aJMaxiejfA1V5SK3OygYmdtmV2u5prX7TnjueJzGSyyaCYEr2JlrRt4YPg==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-push-notification": {
@@ -13218,6 +13265,19 @@
       },
       "peerDependencies": {
         "react": "^17.0.0"
+      }
+    },
+    "node_modules/react-native-tab-view": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-3.5.2.tgz",
+      "integrity": "sha512-nE5WqjbeEPsWQx4mtz81QGVvgHRhujTNIIZiMCx3Bj6CBFDafbk7XZp9ocmtzXUQaZ4bhtVS43R4FIiR4LboJw==",
+      "dependencies": {
+        "use-latest-callback": "^0.1.5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-pager-view": "*"
       }
     },
     "node_modules/react-native-webview": {
@@ -15461,6 +15521,14 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/use-latest-callback": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.1.6.tgz",
+      "integrity": "sha512-VO/P91A/PmKH9bcN9a7O3duSuxe6M14ZoYXgA6a8dab8doWNdhiIHzEkX/jFeTTRBsX0Ubk6nG4q2NIjNsj+bg==",
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/use-sync-external-store": {
@@ -18794,7 +18862,6 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/push-notification-ios/-/push-notification-ios-1.10.1.tgz",
       "integrity": "sha512-k6bZWUKLif4GjenyTD3aQLwA2VT3bNmt22INO/34lexnpmqkPDZF7nreqbckTHG0Zso9wDTe4N/AZJUC/d8iRg==",
-      "peer": true,
       "requires": {
         "invariant": "^2.2.4"
       }
@@ -25558,10 +25625,19 @@
       }
     },
     "react-native-branch": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/react-native-branch/-/react-native-branch-5.5.0.tgz",
-      "integrity": "sha512-f1kv/+tVyqPPKKobstcS8CO2u9PIZBgMDFsSPPrPZP6AZm1FyYDrifbdpJRRbfyky/fApEUNBgl0ZAC+ABPQyA==",
-      "requires": {}
+      "version": "file:..",
+      "requires": {
+        "@babel/core": "^7.20.0",
+        "@babel/preset-env": "^7.20.0",
+        "@babel/runtime": "^7.20.0",
+        "@react-native-community/eslint-config": "^3.0.0",
+        "babel-jest": "^29.2.1",
+        "eslint": "^8.19.0",
+        "eslint-config-rackt": "^1.1.1",
+        "jest": "^29.2.1",
+        "react": "18.2.0",
+        "react-native": "0.71.4"
+      }
     },
     "react-native-codegen": {
       "version": "0.69.1",
@@ -25598,6 +25674,12 @@
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz",
       "integrity": "sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g=="
     },
+    "react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "requires": {}
+    },
     "react-native-json-tree": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-native-json-tree/-/react-native-json-tree-1.3.0.tgz",
@@ -25605,6 +25687,15 @@
       "requires": {
         "prop-types": "^15.7.2",
         "react-base16-styling": "^0.8.0"
+      }
+    },
+    "react-native-keyboard-aware-scroll-view": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.5.tgz",
+      "integrity": "sha512-XwfRn+T/qBH9WjTWIBiJD2hPWg0yJvtaEw6RtPCa5/PYHabzBaWxYBOl0usXN/368BL1XktnZPh8C2lmTpOREA==",
+      "requires": {
+        "prop-types": "^15.6.2",
+        "react-native-iphone-x-helper": "^1.0.3"
       }
     },
     "react-native-modal": {
@@ -25615,6 +25706,12 @@
         "prop-types": "^15.6.2",
         "react-native-animatable": "1.3.3"
       }
+    },
+    "react-native-pager-view": {
+      "version": "5.4.25",
+      "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-5.4.25.tgz",
+      "integrity": "sha512-3drrYwaLat2fYszymZe3nHMPASJ4aJMaxiejfA1V5SK3OygYmdtmV2u5prX7TnjueJzGSyyaCYEr2JlrRt4YPg==",
+      "requires": {}
     },
     "react-native-push-notification": {
       "version": "8.1.1",
@@ -25643,6 +25740,14 @@
           "integrity": "sha512-yQaiOqDmoKqks56LN9MTgY06O0qQHgV4FUrikH357DydArSZHQhl0BJFqGKIZoTqi8JizF9Dxhuk1FIZD6qCaw==",
           "requires": {}
         }
+      }
+    },
+    "react-native-tab-view": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-3.5.2.tgz",
+      "integrity": "sha512-nE5WqjbeEPsWQx4mtz81QGVvgHRhujTNIIZiMCx3Bj6CBFDafbk7XZp9ocmtzXUQaZ4bhtVS43R4FIiR4LboJw==",
+      "requires": {
+        "use-latest-callback": "^0.1.5"
       }
     },
     "react-native-webview": {
@@ -27376,6 +27481,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "use-latest-callback": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.1.6.tgz",
+      "integrity": "sha512-VO/P91A/PmKH9bcN9a7O3duSuxe6M14ZoYXgA6a8dab8doWNdhiIHzEkX/jFeTTRBsX0Ubk6nG4q2NIjNsj+bg==",
+      "requires": {}
     },
     "use-sync-external-store": {
       "version": "1.2.0",

--- a/branch-sdk-automation-testbed/package.json
+++ b/branch-sdk-automation-testbed/package.json
@@ -20,7 +20,7 @@
     "@types/react-native-push-notification": "^8.1.1",
     "react": "18.0.0",
     "react-native": "0.69.1",
-    "react-native-branch": "^5.5.0",
+    "react-native-branch": "file:..",
     "react-native-dropdown-picker": "^5.4.2",
     "react-native-json-tree": "^1.3.0",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",


### PR DESCRIPTION
## Reference
SDK-2137 -- [React Native] Use working directory for automation tests

## Summary
We noticed while intending to deploy an urgent fix that the automation was pointing to a hardcoded version of the react-native-branch sdk. To make testing faster, the automation should automatically pick up new changes which can be done by local reference.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
