### PR TITLE
[SDK-2140] Update iOS SDK to v3.0.0 and raise minimum to iOS 12.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,19 @@
 2023-10-10 Version 6.0.0
 
-- Update Branch iOS SDK to 3.0.0
+- Update Branch iOS SDK to 3.0.0 for iOS 17 support.
+  - Add a Privacy Manifest for the Branch SDK.
+  - Add support for a tracking domain. When Ads tracking is enabled, the SDK sends event calls to a tracking domain.
+  - SetIdentity and Logout are now handled device side
+  - Remove deprecated code and some data minimization
+    - Cross Platform ID
+    - Credits and Referrals
+    - Close requests
+    - Facebook App Links and related code.
+    - Pre-iOS 14 tracking status. This is always false on recent iOS versions.
+    - Tune data upgrade check
+    - v1 Branch Events, all events are now v2 Branch Events
+    - Pre-iOS 10 locale support
+    - Device carrier. This was used for fraud analysis, but is no longer available on new iOS versions.
 - Update minimum iOS version to 12.0
 
 2023-10-03 Version 5.9.2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+2023-10-10 Version 6.0.0
+
+- Update Branch iOS SDK to 3.0.0
+- Update minimum iOS version to 12.0
+
 2023-10-03 Version 5.9.2
   - Update Android SDK to 5.7.1 to include gclid bug fix.
 

--- a/branchreactnativetestbed/package.json
+++ b/branchreactnativetestbed/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-native": "0.71.4",
-    "react-native-branch": "5.9.2-alpha.0"
+    "react-native-branch": "6.0.0-alpha.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/ios/RNBranch.h
+++ b/ios/RNBranch.h
@@ -3,7 +3,6 @@
 
 #import <BranchSDK/Branch.h>
 #import <BranchSDK/BranchQRCode.h>
-#import <BranchSDK/BNCCommerceEvent.h>
 
 extern NSString * _Nonnull const RNBranchLinkOpenedNotification;
 extern NSString * _Nonnull const RNBranchLinkOpenedNotificationErrorKey;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-branch",
-  "version": "5.9.2",
+  "version": "6.0.0",
   "description": "Branch Metrics React Native SDK",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/react-native-branch.podspec
+++ b/react-native-branch.podspec
@@ -17,12 +17,12 @@ Pod::Spec.new do |s|
                    }
   s.license      = spec['license']
   s.homepage     = spec['homepage']
-  s.platform     = :ios, "11.0"
+  s.platform     = :ios, "12.0"
   s.source       = { spec['repository']['type'].to_sym => spec['repository']['url'].sub(/^[a-z]+\+/, '') }
   s.source_files = [ "ios/*.h", "ios/*.m"]
   s.compiler_flags = %[-DRNBRANCH_VERSION=@\\"#{s.version}\\"]
   s.header_dir   = 'RNBranch' # also sets generated module name
-  s.dependency 'BranchSDK', '2.2.1'
+  s.dependency 'BranchSDK', '3.0.0'
   s.dependency 'React-Core' # to ensure the correct build order
   
   # Swift/Objective-C compatibility


### PR DESCRIPTION
## Reference
SDK-2140 -- Release 6.0.0

## Summary
This PR upgrades the Branch iOS SDK from v2.2.0 to v3.0.0 and raises the minimum iOS version to 12.0. 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To keep React Native up to date with the native iOS SDK.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Run the testbed or integrate the `6.0.0-alpha.2` package into a react native app.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
