### PR TITLE
SDK-2192

### DIFF
--- a/branchreactnativetestbed/ios/branchreactnativetestbed/Info.plist
+++ b/branchreactnativetestbed/ios/branchreactnativetestbed/Info.plist
@@ -20,6 +20,17 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>branchtest</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
@@ -54,7 +65,7 @@
 	<key>branch_key</key>
 	<dict>
 		<key>live</key>
-		<string>key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv</string>
+		<string>key_live_hcnegAumkH7Kv18M8AOHhfgiohpXq5tB</string>
 		<key>test</key>
 		<string>key_test_oiBNmHw3FQWznLFSe2rQxaogutkr3ymN</string>
 	</dict>

--- a/branchreactnativetestbed/ios/branchreactnativetestbed/branchreactnativetestbed.entitlements
+++ b/branchreactnativetestbed/ios/branchreactnativetestbed/branchreactnativetestbed.entitlements
@@ -4,10 +4,10 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:5vwu.app.link</string>
-		<string>applinks:5vwu.test-app.link</string>
-		<string>applinks:5vwu-alternate.test-app.link</string>
-		<string>applinks:5wvu-alternate.app.link</string>
+		<string>applinks:bnctestbed.app.link</string>
+		<string>applinks:bnctestbed.test-app.link</string>
+		<string>applinks:bnctestbed-alternate.test-app.link</string>
+		<string>applinks:bnctestbed-alternate.app.link</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Reference
SDK-2192 --RN - iOS linking failure on iOS 16+
https://branch.atlassian.net/browse/SDK-2192 

## Summary
Updated Keys and linking domain in RN Branch Testbed.

## Motivation
Fixing linking issue in testbed app.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Test deep linking for testbed app.

cc @BranchMetrics/saas-sdk-devs for visibility.
