### PR TITLE
[SDK-2199] Added addSnapPartnerParam()

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -497,6 +497,12 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
         branch.addFacebookPartnerParameterWithName(name, value);
     }
 
+        @ReactMethod
+    public void addSnapPartnerParameter(String name, String value) {
+        Branch branch = Branch.getInstance();
+        branch.addSnapPartnerParameterWithName(name, value);
+    }
+
     @ReactMethod
     public void clearPartnerParameters() {
         Branch branch = Branch.getInstance();

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -497,7 +497,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
         branch.addFacebookPartnerParameterWithName(name, value);
     }
 
-        @ReactMethod
+    @ReactMethod
     public void addSnapPartnerParameter(String name, String value) {
         Branch branch = Branch.getInstance();
         branch.addSnapPartnerParameterWithName(name, value);

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -315,6 +315,14 @@ RCT_EXPORT_METHOD(
     [self.class.branch addFacebookPartnerParameterWithName:name value:value];
 }
 
+#pragma mark addSnapPartnerParameter
+RCT_EXPORT_METHOD(
+                  addSnapPartnerParameter:(NSString *)name
+                  value:(NSString *)value
+                  ) {
+    [self.class.branch addSnapPartnerParameterWithName:name value:value];
+}
+
 #pragma mark disableTracking
 RCT_EXPORT_METHOD(
                   disableTracking:(BOOL)disable

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -328,6 +328,7 @@ interface Branch {
   setIdentityAsync: (identity: string) => Promise<BranchParams>;
   setRequestMetadata: (key: string, value: string) => void;
   addFacebookPartnerParameter: (name: string, value: string) => void;
+  addSnapPartnerParameter: (name: string, value: string) => void;
   clearPartnerParameters: () => void;
   logout: () => void;
   openURL: (url: string, options?: { newActivity?: boolean }) => void;

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,10 @@ class Branch {
     console.info('[Branch] addFacebookPartnerParameter has limitations when called from JS.  Some network calls are made prior to the JS layer being available, those calls will not have the partner parameters.')
     return RNBranch.addFacebookPartnerParameter(name, value)
   }
+  addSnapPartnerParameter = (name, value) => {
+    console.info('[Branch] addSnapPartnerParameter has limitations when called from JS.  Some network calls are made prior to the JS layer being available, those calls will not have the partner parameters.')
+    return RNBranch.addSnapPartnerParameter(name, value)
+  }
   clearPartnerParameters = RNBranch.clearPartnerParameters
   logout = RNBranch.logout
   getShortUrl = RNBranch.getShortUrl


### PR DESCRIPTION
## Reference
SDK-2199 -- Expose snap partner parameters API

## Summary
Exposed the `addSnapPartnerParam` JS method from the native SDKs.

## Motivation
We added this method to our iOS and Android SDKs but haven't exposed it in the JS layer yet, so clients haven't been able to use it.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Run a test app and try to use the method to set the Snap partner parameter. Check that it is properly set, included in requests, and cleared by `clearPartnerParams()`.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
