### PR TITLE
Release 6.1.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,11 @@
+2024-02-29 Version 6.1.0
+
+  - Update Android SDK to 5.9.0
+  - Update iOS SDK 3.2.0
+  - Added addSnapPartnerParameter() to support setting Snapchat partner parameters
+  - Added setDMAParamsForEEA() to support DMA compliance
+  - Removed deprecated setDebug() method
+
 2023-10-10 Version 6.0.0
 
 - Update Branch iOS SDK to 3.0.0 for iOS 17 support.

--- a/branchreactnativetestbed/package.json
+++ b/branchreactnativetestbed/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-native": "0.72.5",
-    "react-native-branch": "6.0.0"
+    "react-native-branch": "6.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-branch",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Branch Metrics React Native SDK",
   "main": "src/index.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
2024-02-29 Version 6.1.0

  - Update Android SDK to 5.9.0
  - Update iOS SDK 3.2.0
  - Added addSnapPartnerParameter() to support setting Snapchat partner parameters
  - Added setDMAParamsForEEA() to support DMA compliance
  - Removed deprecated setDebug() method