### PR TITLE
[SDK-2326] Add setAPIUrl to the JS layer

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,5 @@ def safeExtGet(prop, fallback) {
 dependencies {
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation 'com.facebook.react:react-native:+' // From node_modules
-    api 'io.branch.sdk.android:library:5.9.0'
+    api 'io.branch.sdk.android:library:5.10.1'
 }

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -1251,4 +1251,9 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
         Branch branch = Branch.getInstance();
         branch.setDMAParamsForEEA(eeaRegion, adPersonalizationConsent, adUserDataUsageConsent);
     }
+
+    @ReactMethod
+    public void setAPIURL(String apiURL) {
+        Branch.setAPIUrl(apiURL);
+    }
 }

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -1253,7 +1253,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setAPIURL(String apiURL) {
-        Branch.setAPIUrl(apiURL);
+    public void setAPIUrl(String apiUrl) {
+        Branch.setAPIUrl(apiUrl + "/");
     }
 }

--- a/branchreactnativetestbed/components/BranchWrapper.ts
+++ b/branchreactnativetestbed/components/BranchWrapper.ts
@@ -11,7 +11,8 @@ export default class BranchWrapper {
 
   componentDidMount() {
     console.log('BranchWrapper componentDidMount');
-
+    branch.setAPIUrl('https://api3.branch.io');
+    
     this._unsubscribeFromBranch = branch.subscribe({
       onOpenStart: ({uri, cachedInitialEvent}) => {
         console.log(

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -744,9 +744,9 @@ RCT_EXPORT_METHOD(setDMAParamsForEEA:(BOOL)eeaRegion AdPersonalizationConsent:(B
     [Branch setDMAParamsForEEA:eeaRegion AdPersonalizationConsent:adPersonalizationConsent AdUserDataUsageConsent:adUserDataUsageConsent];
 }
 
-#pragma mark setAPIURL
-RCT_EXPORT_METHOD(setAPIURL:(NSString *)apiURL) {
-    [Branch setAPIURL:apiURL];
+#pragma mark setAPIUrl
+RCT_EXPORT_METHOD(setAPIUrl:(NSString *)apiUrl) {
+    [Branch setAPIUrl:apiUrl];
 }
 
 @end

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -744,4 +744,9 @@ RCT_EXPORT_METHOD(setDMAParamsForEEA:(BOOL)eeaRegion AdPersonalizationConsent:(B
     [Branch setDMAParamsForEEA:eeaRegion AdPersonalizationConsent:adPersonalizationConsent AdUserDataUsageConsent:adUserDataUsageConsent];
 }
 
+#pragma mark setAPIURL
+RCT_EXPORT_METHOD(setAPIURL:(NSString *)apiURL) {
+    [Branch setAPIURL:apiURL];
+}
+
 @end

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -348,6 +348,7 @@ interface Branch {
   setPreInstallCampaign: (campaign: string) => void;
   setPreInstallPartner: (partner: string) => void;
   setDMAParamsForEEA: (eeaRegion: boolean, adPersonalizationConsent: boolean, adUserDataUsageConsent: boolean) => void;
+  setAPIURL: (url: string) => void;
 }
 declare const branch: Branch;
 export default branch;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -348,7 +348,7 @@ interface Branch {
   setPreInstallCampaign: (campaign: string) => void;
   setPreInstallPartner: (partner: string) => void;
   setDMAParamsForEEA: (eeaRegion: boolean, adPersonalizationConsent: boolean, adUserDataUsageConsent: boolean) => void;
-  setAPIURL: (url: string) => void;
+  setAPIUrl: (url: string) => void;
 }
 declare const branch: Branch;
 export default branch;

--- a/src/index.js
+++ b/src/index.js
@@ -164,6 +164,17 @@ class Branch {
       console.warn("setDMAParamsForEEA: Unable to set DMA params.");
     }
   };
+
+  /*** Set the Branch API's base URL ***/
+  setAPIURL = (apiUrl) => {
+    if (!apiUrl || typeof apiUrl !== "string" || !apiUrl.startsWith("http")) {
+      console.warn(
+        "setAPIURL: Invalid URL. URL must be a non-empty string starting with 'http'."
+      );
+      return;
+    }
+    RNBranch.setAPIURL(apiUrl);
+  };
 }
 
 const validateParam = (param, paramName) => {

--- a/src/index.js
+++ b/src/index.js
@@ -165,15 +165,15 @@ class Branch {
     }
   };
 
-  /*** Set the Branch API's base URL ***/
-  setAPIURL = (apiUrl) => {
+  /*** Set the Branch API's base URL (eg. "https://api2.branch.io") ***/
+  setAPIUrl = (apiUrl) => {
     if (!apiUrl || typeof apiUrl !== "string" || !apiUrl.startsWith("http")) {
       console.warn(
-        "setAPIURL: Invalid URL. URL must be a non-empty string starting with 'http'."
+        "setAPIUrl: Invalid URL. URL must be a non-empty string starting with 'http'."
       );
       return;
     }
-    RNBranch.setAPIURL(apiUrl);
+    RNBranch.setAPIUrl(apiUrl);
   };
 }
 


### PR DESCRIPTION
## Reference
SDK-2326 --  Expose the setAPIUrl method in the JS layer

## Summary
Added the setAPIUrl to the JS layer now that it exists on both of the native layers.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Bring the React Native SDK to parity with out iOS and Android native SDKs.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Call the new method with a cusrtom API URL. To have the initial open/install use the endpoint, it needs to be set early. 
Calling `branch.setAPIUrl('https://api3.branch.io')` in the Testbed's `componentDidMount` works in that case.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
