### PR TITLE
[SDK-2345] Updated native SDK versions to support setting apiURL in branch.json

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
+2024-04-01 Version 6.2.0
+
+  - Update Android SDK to 5.11.0
+  - Update iOS SDK 3.4.0
+  - Added support for changing the Branch base API URL through the `branch.json` file
+
 2024-02-29 Version 6.1.0
 
   - Update Android SDK to 5.9.0

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,5 @@ def safeExtGet(prop, fallback) {
 dependencies {
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation 'com.facebook.react:react-native:+' // From node_modules
-    api 'io.branch.sdk.android:library:5.9.0'
+    api 'io.branch.sdk.android:library:5.11.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-branch",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Branch Metrics React Native SDK",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/react-native-branch.podspec
+++ b/react-native-branch.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.source_files = [ "ios/*.h", "ios/*.m"]
   s.compiler_flags = %[-DRNBRANCH_VERSION=@\\"#{s.version}\\"]
   s.header_dir   = 'RNBranch' # also sets generated module name
-  s.dependency 'BranchSDK', '3.2.0'
+  s.dependency 'BranchSDK', '3.4.0'
   s.dependency 'React-Core' # to ensure the correct build order
   
   # Swift/Objective-C compatibility


### PR DESCRIPTION
## Reference
SDK-2345 -- Updated native SDK versions to support setting apiURL in branch.json

## Summary
Updated the iOS and Android SDK versions to the latest. Also updated the plugin version and changelog.md.

## Motivation
With these versions, React Native users will be able to change the Branch API base URL via the branch.json files.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Add "apiUrl": "https://api.branch.io" to the Android and iOS branch.json files in a test app. Observe that all of the Branch requests now use this URL.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
