### PR TITLE
Update to iOS 3.4.1 and bump version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+2023-04-03 Version 6.2.1
+  - Fix issue with deeplinks getting lost on iOS when the App is closed and deferInitForPluginRuntime is enabled
+  - Update iOS SDK 3.4.1
+
 2024-04-01 Version 6.2.0
 
   - Update Android SDK to 5.11.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-2023-04-03 Version 6.2.1
+2024-04-03 Version 6.2.1
   - Fix issue with deeplinks getting lost on iOS when the App is closed and deferInitForPluginRuntime is enabled
   - Update iOS SDK 3.4.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-branch",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Branch Metrics React Native SDK",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/react-native-branch.podspec
+++ b/react-native-branch.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.source_files = [ "ios/*.h", "ios/*.m"]
   s.compiler_flags = %[-DRNBRANCH_VERSION=@\\"#{s.version}\\"]
   s.header_dir   = 'RNBranch' # also sets generated module name
-  s.dependency 'BranchSDK', '3.4.0'
+  s.dependency 'BranchSDK', '3.4.1'
   s.dependency 'React-Core' # to ensure the correct build order
   
   # Swift/Objective-C compatibility


### PR DESCRIPTION
## Reference
SDK-2352 update to iOS SDK 3.4.1

## Summary
This update fixes an issue with deeplinks getting lost on iOS when the App is closed and `deferInitForPluginRuntime` is enabled

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)
