### PR TITLE
fix(types): allow custom fields in BranchLinkControlParams

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -268,14 +268,14 @@ export interface BranchLinkProperties {
   tags?: string[];
 }
 
-export interface BranchLinkControlParams {
+export type BranchLinkControlParams = {
   $fallback_url?: string;
   $desktop_url?: string;
   $ios_url?: string;
   $ipad_url?: string;
   $android_url?: string;
   $samsung_url?: string;
-}
+} & Record<string, string>;
 
 interface BranchShareSuccess {
   completed: true;


### PR DESCRIPTION
## Reference
SDK-XXXX -- <TITLE>.

## Summary
<!-- Simple summary of what was changed. -->

Updates the `BranchLinkControlParams` to allow custom entries.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

The documentation says this is how custom data, such as `referring_user_id` should be added to deep links, but the types didn't allow for this. Ignoring the types and testing link generation showed that values were passed through successfully, so no change was needed on the code side.

From my testing, all values passed here (strings, numbers, booleans, nulls) were stringified, so I went with `Record<string, string>` as the type so that users will expect strings on the other side. I also found that passing an explicit `undefined` would drop the key entirely from the result, so I thought the `Record` approach was better than `[custom: string]: string | undefined`, where users might expect the key to be present but with no value, or a `null` when they handle the deep link.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.

---

As an aside, your CONTRIBUTING.md still points to an issue tracker, even though issues seem to have been disabled for this repo.