### PR TITLE
Add setFBAppID method for Android

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -1257,4 +1257,11 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     public void validateSDKIntegration() {
         IntegrationValidator.validate(mActivity);
     }
+
+    @ReactMethod
+    public void setFBAppID(String fbAppID) {
+        Branch branch = Branch.getInstance();
+        branch.setFBAppID(fbAppID);
+    }
+
 }

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -750,4 +750,10 @@ RCT_EXPORT_METHOD(validateSDKIntegration) {
     [[Branch getInstance] validateSDKIntegration];
 }
 
+#pragma mark setIdentity
+RCT_EXPORT_METHOD(
+                  setFBAppID:(NSString *)fbAppID
+                  ) {
+}
+
 @end

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -349,6 +349,7 @@ interface Branch {
   setPreInstallPartner: (partner: string) => void;
   setDMAParamsForEEA: (eeaRegion: boolean, adPersonalizationConsent: boolean, adUserDataUsageConsent: boolean) => void;
   validateSDKIntegration: () => void;
+  setFBAppID: (fbAppID: string) => void;
 }
 declare const branch: Branch;
 export default branch;

--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,9 @@ class Branch {
 
   validateSDKIntegration = () => {
     RNBranch.validateSDKIntegration();
-  };  
+  };
+
+  setFBAppID = (fbAppID) => RNBranch.setFBAppID(fbAppID);
 }
 
 const validateParam = (param, paramName) => {


### PR DESCRIPTION
## Reference
SDK-6.4.0 -- Add setFBAppID method.

## Summary
Add setFBAppID method for Android. This method will be a No-op on iOS.

## Motivation
The setFBAppID method is missing from the React Native SDK but it is required for setting up [Meta Install Referrer](https://help.branch.io/using-branch/docs/facebook-install-referrer)

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Testing Instructions
Call setFBAppID from React Native code and check if it flows to Android.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
